### PR TITLE
fix the picker to not assert on single-item datasets

### DIFF
--- a/widgets/pickable.py
+++ b/widgets/pickable.py
@@ -97,6 +97,10 @@ class GenericPickable:
         self.xscreen, self.yscreen = screenvals
 
     def _pickSign(self, i):
+        if len(self.xscreen) <= 1:
+            # we only have one element, so it doesn't matter anyways
+            return 1
+        
         if i == 0:
             m = None
         else:


### PR DESCRIPTION
Single-item datasets don't have enough items to establish an ordering, so pickable.py:_chooseOrderingSign() was asserting. Fix that.
