### PR TITLE
Fix Issue #10

### DIFF
--- a/document/doc.py
+++ b/document/doc.py
@@ -405,7 +405,7 @@ class Document( qt4.QObject ):
         except KeyError:
             pass
         fileobj.write('# Date: %s\n\n' %
-                      time.strftime("%a, %d %b %Y %H:%M:%S +0000",
+                      time.strftime("%d/%m/%Y %H:%M:%S +0000",
                                     time.gmtime()) )
         
     def saveCustomDefinitions(self, fileobj):


### PR DESCRIPTION
Export stylesheet function includes a "Date" field which may contain
different encodings depending on the locales. In some case, it may
not been possible to load the saved stylesheet because of missmatch
encodings (see PEP 0263). The Date field has been simplified to avoid
any problem.

Note: the "User" field may cause the same problem in some case.
