### PR TITLE
Use Astropy by default instead of PyFITS

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -18,7 +18,7 @@ PyQt requires
  SIP >= 4.12     http://www.riverbankcomputing.co.uk/software/sip/
 
 Optional requirements:
- PyFITS >=1.1    http://www.stsci.edu/resources/software_hardware/pyfits
+ Astropy >= 0.2  http://www.astropy.org
  pyemf >= 2.0.0  http://pyemf.sourceforge.net/
  PyMinuit        http://code.google.com/p/pyminuit/
  dbus-python     http://dbus.freedesktop.org/doc/dbus-python/

--- a/veusz/dialogs/importdialog.py
+++ b/veusz/dialogs/importdialog.py
@@ -501,10 +501,14 @@ class ImportTabFITS(ImportTab):
         global pyfits
         if pyfits is None:
             try:
-                import pyfits as PF
+                from astropy.io import fits as PF
                 pyfits = PF
             except ImportError:
-                pyfits = None
+                try:
+                    import pyfits as PF
+                    pyfits = PF
+                except ImportError:
+                    pyfits = None
 
         # if it isn't
         if pyfits is None:

--- a/veusz/document/operations.py
+++ b/veusz/document/operations.py
@@ -1050,10 +1050,13 @@ class OperationDataImportFITS(OperationDataImportBase):
         """Do the import."""
 
         try:
-            import pyfits
+            from astropy.io import fits as pyfits
         except ImportError:
-            raise RuntimeError( 'PyFITS is required to import '
-                                  'data from FITS files')
+            try:
+                import pyfits
+            except ImportError:
+                raise RuntimeError('Either Astropy or PyFITS is required '
+                                   'to import data from FITS files')
 
         p = self.params
         f = pyfits.open( str(p.filename), 'readonly')


### PR DESCRIPTION
As @mindw mentioned in https://github.com/astropy/astropy/pull/1493, it is not currently possible to use Astropy instead of PyFITS for veusz. PyFITS is going to be deprecated on a timescale of a ~year so it is now time to switch to using `astropy.io.fits` whenever possible. I wasn't sure whether it would make sense to have the fallback on PyFITS if Astropy is not installed or whether we should do a clean break and simply require Astropy? (I'm happy to update this PR).

I had issues building veusz (will open a separate issue) so cannot test that this works correctly at the moment - but maybe you make use of Travis?
