### PR TITLE
Enable SAMP from astropy.io.samp

### DIFF
--- a/README
+++ b/README
@@ -97,7 +97,7 @@ Optional requirements:
    http://dbus.freedesktop.org/doc/dbus-python/
  astropy (optional for VO table import)
    http://www.astropy.org/
- SAMPy (optional for SAMP support)
+ SAMPy or astropy >= 0.4 (optional for SAMP support)
    http://pypi.python.org/pypi/sampy/
 
 Veusz is Copyright (C) 2003-2014 Jeremy Sanders <jeremy@jeremysanders.net>

--- a/veusz/compat.py
+++ b/veusz/compat.py
@@ -34,7 +34,7 @@ if cpy3:
 
     # builtins
     import builtins as cbuiltins
-    from io import StringIO as CStringIO
+    from io import StringIO as CStringIO, BytesIO as CBytesIO
     import urllib.request as curlrequest
 
     # imports
@@ -99,6 +99,7 @@ else:
     # imports
     import cPickle as pickle
     from StringIO import StringIO as CStringIO
+    from io import BytesIO as CBytesIO
     import urllib2 as curlrequest
 
     # range function

--- a/veusz/plugins/votable.py
+++ b/veusz/plugins/votable.py
@@ -17,7 +17,7 @@
 
 from __future__ import division, print_function
 
-from ..compat import CStringIO, curlrequest
+from ..compat import CStringIO, CBytesIO, curlrequest
 from .importplugin import ImportPlugin, importpluginregistry
 from .datasetplugin import Dataset1D, DatasetText
 
@@ -39,8 +39,12 @@ else:
 
         def _load_votable(self, params):
             if 'url' in params.field_results:
-                buff = CStringIO(curlrequest.urlopen(
-                        params.field_results['url']).read())
+                try:
+                    buff = CStringIO(curlrequest.urlopen(
+                            params.field_results['url']).read())
+                except TypeError:
+                    buff = CBytesIO(curlrequest.urlopen(
+                            params.field_results['url']).read())
                 return parse(buff, filename=params.filename)
             else:
                 return parse(params.filename)

--- a/veusz/utils/vzsamp.py
+++ b/veusz/utils/vzsamp.py
@@ -29,11 +29,23 @@ try:
                       SAMP_STATUS_OK, SAMP_STATUS_ERROR
 
 except ImportError:
-    def setup():
-        print('SAMP: sampy module not available')
+
+    try:
+        from astropy.vo.samp import SAMPIntegratedClient, SAMPHubError, \
+                      SAMP_STATUS_OK, SAMP_STATUS_ERROR
+    except ImportError:
+        SM = False
+        def setup():
+            print('SAMP: sampy module not available')
+    else:
+        SM = True
 
 else:
+    SM = True
+
+if SM:
     def load_votable(private_key, sender_id, msg_id, mtype, params, extra):
+        print(params)
         try:
             url = params['url']
             name = params['name']
@@ -75,8 +87,10 @@ else:
             samp.connect()
 
             atexit.register(close)
-
-            samp.bindReceiveCall('table.load.votable', load_votable)
+            try:
+                samp.bindReceiveCall('table.load.votable', load_votable)
+            except AttributeError:
+                samp.bind_receive_call('table.load.votable', load_votable)
 
         except SAMPHubError:
             print('SAMP: could not connect to hub')


### PR DESCRIPTION
This is my first attempt at a pull request. I made these modification in order to be able to receive SAMP tables using astropy instead of sampy. I have tested these changes using python 3.3.5 and 2.7.8, and it seems to work, but some more testing is probably nedded.
