### PR TITLE
added .travis.yml for continous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: python
+sudo: false
+branches:
+  only:
+    - master
+python:
+  - "2.7"
+apt:
+  packages:
+    - debhelper 
+    - docbook-utils 
+    - docbook-xml 
+    - graphicsmagick 
+    - libqt4-dev perl 
+    - python-all-dbg 
+    - python-all-dev 
+    - python-numpy 
+    - python-numpy-dbg 
+    - python-qt4-dbg 
+    - python-qt4-dev 
+    - python-sip-dbg 
+    - python-sip-dev 
+    - xauth 
+    - xfonts-base
+    - xvfb
+install:
+  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q --yes conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda create -q -n test-environment python=2.7 nose numpy scipy pytables pycrypto pyqt pygments pil
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3
+script:
+  - source activate test-environment
+  - export VEUSZ_RESOURCE_DIR=$(pwd)
+  - export PYTHONPATH=$(pwd)
+  - echo $PYTHONPATH $VEUSZ_RESOURCE_DIR
+  - python setup.py build_ext --inplace
+  - python tests/runselftest.py
+cache:
+  - apt
+  - directories:
+    - $HOME/.cache/pip


### PR DESCRIPTION
This allows Veusz tests to be ran at each commit and results displayed eg here: https://travis-ci.org/tainstr/veusz.
This version of travis.yml only considers python 2.7, but other versions can be added in the same place.
