### PR TITLE
Add OpenBSD to this list.

### DIFF
--- a/veusz/helpers/src/qtloops/isnan.h
+++ b/veusz/helpers/src/qtloops/isnan.h
@@ -33,7 +33,7 @@
 # define isNaN(_a) (__isnan(_a))	/* MacOSX/Darwin definition < 10.4 */
 #elif defined(WIN32) || defined(_isnan) || defined(_MSC_VER)
 # define isNaN(_a) (_isnan(_a)) 	/* Win32 definition */
-#elif defined(isnan) || defined(__FreeBSD__) || defined(__osf__)
+#elif defined(isnan) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__osf__)
 # define isNaN(_a) (isnan(_a))		/* GNU definition */
 #else
 # define isNaN(_a) (std::isnan(_a))
@@ -50,7 +50,7 @@
 # define isFinite(_a) (_finite(_a)) 	/* Win32 definition */
 #elif defined(__sgi)
 # define isFinite(_a) (_isfinite(_a))
-#elif defined(isfinite) || defined(__FreeBSD__)
+#elif defined(isfinite) || defined(__FreeBSD__) || defined(__OpenBSD__)
 # define isFinite(_a) (isfinite(_a))
 #elif defined(__osf__)
 # define isFinite(_a) (finite(_a) && !isNaN(_a))


### PR DESCRIPTION
Hi --

We have been keeping this patch for a while for the OpenBSD package.
With this, Veusz compiles cleanly on OpenBSD.

Thanks.