### PR TITLE
Use unsigned long for widget ids instead of signed long

### DIFF
--- a/veusz/helpers/src/threed/objects.cpp
+++ b/veusz/helpers/src/threed/objects.cpp
@@ -31,7 +31,7 @@ void Object::getFragments(const Mat4& perspM, const Mat4& outerM, FragmentVector
 {
 }
 
-void Object::assignWidgetId(long id)
+void Object::assignWidgetId(unsigned long id)
 {
   widgetid = id;
 }
@@ -729,7 +729,7 @@ void ObjectContainer::getFragments(const Mat4& perspM, const Mat4& outerM, Fragm
     objects[i]->getFragments(perspM, totM, v);
 }
 
-void ObjectContainer::assignWidgetId(long id)
+void ObjectContainer::assignWidgetId(unsigned long id)
 {
   for(auto &object : objects)
     object->assignWidgetId(id);

--- a/veusz/helpers/src/threed/objects.h
+++ b/veusz/helpers/src/threed/objects.h
@@ -33,17 +33,17 @@
 class Object
 {
  public:
-  Object() : widgetid(-1) {}
+  Object() : widgetid(0) {}
 
   virtual ~Object();
 
   virtual void getFragments(const Mat4& perspM, const Mat4& outerM, FragmentVector& v);
 
   // recursive set id of child objects
-  virtual void assignWidgetId(long id);
+  virtual void assignWidgetId(unsigned long id);
 
   // id of widget which generated object
-  long widgetid;
+  unsigned long widgetid;
 };
 
 class Triangle : public Object
@@ -298,7 +298,7 @@ class ObjectContainer : public Object
   }
 
   // recursive set id of child objects
-  void assignWidgetId(long id);
+  void assignWidgetId(unsigned long id);
 
  public:
   Mat4 objM;

--- a/veusz/helpers/src/threed/scene.cpp
+++ b/veusz/helpers/src/threed/scene.cpp
@@ -528,12 +528,12 @@ Scene::DrawCallback::~DrawCallback()
 {
 }
 
-long Scene::idPixel(Object* root,
-                    QPainter* painter,
-                    const Camera& cam,
-                    double x1, double y1, double x2, double y2,
-                    double scale,
-                    double scaling, int x, int y)
+unsigned long Scene::idPixel(Object* root,
+                             QPainter* painter,
+                             const Camera& cam,
+                             double x1, double y1, double x2, double y2,
+                             double scale,
+                             double scaling, int x, int y)
 {
   constexpr int box = 3;
 
@@ -543,7 +543,7 @@ long Scene::idPixel(Object* root,
   {
   public:
     IdDrawCallback()
-      : lastwidgetid(-1),
+      : lastwidgetid(0),
         pixrender(2*box+1,2*box+1)
     {
       pixrender.fill(QColor(254,254,254));
@@ -565,7 +565,7 @@ long Scene::idPixel(Object* root,
         }
     }
 
-    long lastwidgetid;
+    unsigned long lastwidgetid;
     QPixmap pixrender;
     QImage lastimage;
   };

--- a/veusz/helpers/src/threed/scene.h
+++ b/veusz/helpers/src/threed/scene.h
@@ -66,9 +66,9 @@ public:
               double x1, double y1, double x2, double y2, double scale);
 
   // find widget id of pixel painted by drawing scene at (x, y)
-  long idPixel(Object* root, QPainter* painter, const Camera& cam,
-               double x1, double y1, double x2, double y2, double scale,
-               double scaling, int x, int y);
+  unsigned long idPixel(Object* root, QPainter* painter, const Camera& cam,
+                        double x1, double y1, double x2, double y2, double scale,
+                        double scaling, int x, int y);
 
 public:
   // last screen matrix

--- a/veusz/helpers/src/threed/threed.sip
+++ b/veusz/helpers/src/threed/threed.sip
@@ -324,8 +324,8 @@ class Object /NoDefaultCtors/
 %End
   public:
    virtual ~Object();
-   virtual void assignWidgetId(long id);
-   long widgetid;
+   virtual void assignWidgetId(unsigned long id);
+   unsigned long widgetid;
 };
 
 class Triangle : public Object /NoDefaultCtors/
@@ -446,7 +446,7 @@ class ObjectContainer : public Object
  public:
   ObjectContainer();
   void addObject(Object* obj /Transfer/);
-  void assignWidgetId(long id);
+  void assignWidgetId(unsigned long id);
 
   Mat4 objM;
 };
@@ -538,11 +538,11 @@ class Scene
   void render(Object* root,
               QPainter* painter, const Camera& cam,
 	      double x1, double y1, double x2, double y2, double scale);
-  long idPixel(Object* root,
-               QPainter* painter, const Camera& cam,
-               double x1, double y1, double x2, double y2,
-               double scale,
-               double scaling, int x, int y);
+  unsigned long idPixel(Object* root,
+                        QPainter* painter, const Camera& cam,
+                        double x1, double y1, double x2, double y2,
+                        double scale,
+                        double scaling, int x, int y);
 
  public:
   Mat3 screenM;


### PR DESCRIPTION
Python’s `id()` function returns memory addresses, which do not fit into signed long on 32-bit systems.

In PyQt 5.12 overflow checking is [enabled by default](https://www.riverbankcomputing.com/news/pyqt-512), so this causes errors like this:

```python
Traceback (most recent call last):
  File "tests/runselftest.py", line 307, in <module>
    test_unlink=options.test_unlink)
  File "tests/runselftest.py", line 236, in runTests
    test_unlink=test_unlink)
  File "tests/runselftest.py", line 173, in renderVszTest
    ifc.Export(outfile)
  File "/usr/lib/python3/dist-packages/veusz/document/commandinterface.py", line 778, in Export
    e.export()
  File "/usr/lib/python3/dist-packages/veusz/document/export.py", line 232, in export
    self.exportSelfTest(self.filename)
  File "/usr/lib/python3/dist-packages/veusz/document/export.py", line 417, in exportSelfTest
    self.renderPage(page, size, (dpi,dpi), painter)
  File "/usr/lib/python3/dist-packages/veusz/document/export.py", line 251, in renderPage
    self.doc.paintTo(helper, page)
  File "/usr/lib/python3/dist-packages/veusz/document/doc.py", line 345, in paintTo
    self.basewidget.draw(painthelper, page)
  File "/usr/lib/python3/dist-packages/veusz/widgets/root.py", line 136, in draw
    page.draw( posn, painthelper )
  File "/usr/lib/python3/dist-packages/veusz/widgets/page.py", line 358, in draw
    parentposn)
  File "/usr/lib/python3/dist-packages/veusz/widgets/widget.py", line 288, in draw
    c.draw(bounds, painthelper, outerbounds=outerbounds)
  File "/usr/lib/python3/dist-packages/veusz/widgets/scene3d.py", line 226, in draw
    root = self.makeObjects(painter, bounds, painthelper)
  File "/usr/lib/python3/dist-packages/veusz/widgets/scene3d.py", line 177, in makeObjects
    obj = c.drawToObject(painter, painthelper)
  File "/usr/lib/python3/dist-packages/veusz/widgets/graph3d.py", line 246, in drawToObject
    cont.assignWidgetId(id(self))
OverflowError: argument 1 overflowed: value must be in the range -2147483648 to 2147483647
```