### PR TITLE
Add option to exclude items from key plot

### DIFF
--- a/veusz/widgets/key.py
+++ b/veusz/widgets/key.py
@@ -175,6 +175,11 @@ class Key(widget.Widget):
                             descr = _('Text settings'),
                             usertext=_('Text')),
                pixmap = 'settings_axislabel' )
+
+        s.add(setting.Str('exclude', '',
+                          descr=_('Exclude item from displaying'),
+                          usertext=_('Exclude item')))
+
         s.add( setting.KeyBrush('Background',
                                 descr = _('Key background fill'),
                                 usertext=_('Background')),
@@ -375,9 +380,12 @@ class Key(widget.Widget):
         # maximum width of text required
         maxwidth = 1
 
+        exclude = list(map(lambda it: it.strip(), s.exclude.split(',')))
         entries = []
         # iterate over children and find widgets which are suitable
         for c in self.parent.children:
+            if c.name in exclude:
+                continue
             try:
                 num = c.getNumberKeys()
             except AttributeError:


### PR DESCRIPTION
Just a small improvement to exclude some items (cvs list) from the key widget. 
Usefull if you have multiple key widgets in one plot and you want to group the items.

![grouping](https://user-images.githubusercontent.com/23076141/66417707-942ca780-e9ce-11e9-9129-01b588cba324.jpg)