### PR TITLE
Fix python 3.9 compatibility for using "U" in open

### DIFF
--- a/veusz/dialogs/histodata.py
+++ b/veusz/dialogs/histodata.py
@@ -71,7 +71,7 @@ class HistoDataDialog(VeuszDialog):
         self.document = document
 
         self.minval.default = self.maxval.default = ['Auto']
-        regexp = qt.QRegExp("^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?|Auto$")
+        regexp = qt.QRegExp(r"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?|Auto$")
         validator = qt.QRegExpValidator(regexp, self)
         self.minval.setValidator(validator)
         self.maxval.setValidator(validator)

--- a/veusz/document/commandinterpreter.py
+++ b/veusz/document/commandinterpreter.py
@@ -48,7 +48,7 @@ import traceback
 import io
 import os.path
 
-from ..compat import pickle, cexec
+from ..compat import pickle, cexec, cpy3
 from .commandinterface import CommandInterface
 from .. import utils
 
@@ -175,7 +175,8 @@ class CommandInterpreter(object):
     def Load(self, filename):
         """Replace the document with a new one from the filename."""
 
-        with io.open(filename, 'rU', encoding='utf8') as f:
+        mode = 'r' if cpy3 else 'rU'
+        with io.open(filename, mode, encoding='utf8') as f:
             self.document.wipe()
             self.interface.To('/')
             oldfile = self.globals['__file__']

--- a/veusz/document/loader.py
+++ b/veusz/document/loader.py
@@ -28,7 +28,7 @@ from .. import qtall as qt4
 from .. import setting
 from .. import utils
 
-from ..compat import cexec, cstrerror, cbytes, cexceptionuser
+from ..compat import cexec, cstrerror, cbytes, cexceptionuser, cpy3
 from .commandinterface import CommandInterface
 from . import datasets
 
@@ -270,7 +270,8 @@ def loadDocument(thedoc, filename, mode='vsz',
 
     if mode == 'vsz':
         try:
-            with io.open(filename, 'rU', encoding='utf-8') as f:
+            mode = 'r' if cpy3 else 'rU'
+            with io.open(filename, mode, encoding='utf-8') as f:
                 script = f.read()
         except EnvironmentError as e:
             raise LoadError( _("Cannot open document '%s'\n\n%s") %

--- a/veusz/document/operations.py
+++ b/veusz/document/operations.py
@@ -32,7 +32,7 @@ import io
 
 import numpy as N
 
-from ..compat import czip, crange, citems, cbasestr
+from ..compat import czip, crange, citems, cbasestr, cpy3
 from . import widgetfactory
 
 from .. import datasets
@@ -1176,7 +1176,8 @@ class OperationLoadStyleSheet(OperationMultiple):
         # fire up interpreter to read file
         interpreter = commandinterpreter.CommandInterpreter(document)
         try:
-            interpreter.runFile( io.open(self.filename, 'rU',
+            mode = 'r' if cpy3 else 'rU'
+            interpreter.runFile( io.open(self.filename, mode,
                                          encoding='utf8') )
         except:
             document.batchHistory(None)

--- a/veusz/document/svg_export.py
+++ b/veusz/document/svg_export.py
@@ -405,7 +405,7 @@ class SVGPaintEngine(qt.QPaintEngine):
                 element.attrb += ' id="p%i"' % num
 
             # if the parent is a translation, swallow this into the use element
-            m = re.match('transform="translate\(([-0-9.]+),([-0-9.]+)\)"',
+            m = re.match(r'transform="translate\(([-0-9.]+),([-0-9.]+)\)"',
                          self.celement.attrb)
             if m:
                 SVGElement(self.celement.parent, 'use',

--- a/veusz/utils/dates.py
+++ b/veusz/utils/dates.py
@@ -243,7 +243,7 @@ def dateStrToRegularExpression(instr):
         out.append( '(?:%s)?' % p )
 
     # return final expression
-    return '^\s*%s\s*$' % (''.join(out))
+    return r'^\s*%s\s*$' % (''.join(out))
 
 def dateREMatchToDate(match):
     """Take match object for above regular expression,


### PR DESCRIPTION
* Fix python 3.9 compatibility for using "U" in open.
* Fix deprecation warning due to invalid escape sequences.

Fixes #371 