### PR TITLE
Add support for SIP v5

### DIFF
--- a/pyqtdistutils.py
+++ b/pyqtdistutils.py
@@ -12,7 +12,6 @@ import subprocess
 
 from distutils.sysconfig import customize_compiler
 import distutils.command.build_ext
-from distutils.dep_util import newer, newer_group
 
 import PyQt5.QtCore
 
@@ -96,20 +95,6 @@ class build_ext(distutils.command.build_ext.build_ext):
         self.qt_include_dir = None
         self.qt_library_dir = None
         self.qt_libinfix = None
-
-    def _get_sip_output_list(self, sbf):
-        '''
-        Parse the sbf file specified to extract the name of the generated source
-        files. Make them absolute assuming they reside in the temp directory.
-        '''
-        for line in open(sbf):
-            key, value = line.split('=', 1)
-            if key.strip() == 'sources':
-                out = []
-                for o in value.split():
-                    out.append(os.path.join(self.build_temp, o))
-                return out
-        raise RuntimeError('cannot parse SIP-generated "%s"' % sbf)
 
     def _get_sip_exe(self, build_cmd):
         """Get exe for sip. Sources are:
@@ -289,26 +274,28 @@ class build_ext(distutils.command.build_ext.build_ext):
         generated_sources = []
 
         for sip in sip_sources:
-            # Use the sbf file as dependency check
-            sipbasename = os.path.basename(sip)
-            sbf = os.path.join(self.build_temp,
-                               replace_suffix(sipbasename, '.sbf'))
-            if newer_group([sip]+depends, sbf) or self.force:
-                self._sip_compile(sip_exe, sip_dir, sip, sbf)
-            out = self._get_sip_output_list(sbf)
+            sip_basename = os.path.basename(sip)[:-4]
+            sip_builddir = os.path.join(self.build_temp, 'sip-' + sip_basename)
+            if not os.path.exists(sip_builddir) or self.force:
+                os.makedirs(sip_builddir, exist_ok=True)
+                self._sip_compile(sip_exe, sip_dir, sip, sip_builddir)
+            out = [
+                os.path.join(sip_builddir, fn)
+                for fn in os.listdir(sip_builddir)
+                if fn.endswith(".cpp")
+            ]
             generated_sources.extend(out)
 
         return generated_sources + other_sources
 
-    def _sip_compile(self, sip_exe, sip_dir, source, sbf):
+    def _sip_compile(self, sip_exe, sip_dir, source, sip_builddir):
         """Compile sip file to sources."""
         self.spawn(
             [
                 sip_exe,
-                '-c', self.build_temp
+                '-c', sip_builddir
             ] + SIP_FLAGS.split() + [
                 '-I', os.path.join(sip_dir, 'PyQt5'),
-                '-b', sbf,
                 source
             ]
         )

--- a/pyqtdistutils.py
+++ b/pyqtdistutils.py
@@ -293,6 +293,8 @@ class build_ext(distutils.command.build_ext.build_ext):
         if 'sip5' in sip_exe:
             pyqt5_include_dir = os.path.join(get_python_lib(plat_specific=1),
                                              'PyQt5', 'bindings')
+            self.spawn(['sip-module', '--target-dir', sip_builddir,
+                        '--sip-h', 'PyQt5.sip'])
         else:
             pyqt5_include_dir = os.path.join(sip_dir, 'PyQt5')
         self.spawn(

--- a/pyqtdistutils.py
+++ b/pyqtdistutils.py
@@ -10,7 +10,7 @@ import sys
 import sysconfig
 import subprocess
 
-from distutils.sysconfig import customize_compiler
+from distutils.sysconfig import customize_compiler, get_python_lib
 import distutils.command.build_ext
 
 import PyQt5.QtCore
@@ -290,12 +290,17 @@ class build_ext(distutils.command.build_ext.build_ext):
 
     def _sip_compile(self, sip_exe, sip_dir, source, sip_builddir):
         """Compile sip file to sources."""
+        if 'sip5' in sip_exe:
+            pyqt5_include_dir = os.path.join(get_python_lib(plat_specific=1),
+                                             'PyQt5', 'bindings')
+        else:
+            pyqt5_include_dir = os.path.join(sip_dir, 'PyQt5')
         self.spawn(
             [
                 sip_exe,
                 '-c', sip_builddir
             ] + SIP_FLAGS.split() + [
-                '-I', os.path.join(sip_dir, 'PyQt5'),
+                '-I', pyqt5_include_dir,
                 source
             ]
         )


### PR DESCRIPTION
This can be tested by installing the latest versions of `sip` and `PyQt5` from PyPI, or by installing `python3-sipbuild` on Debian and `python3-pyqt5`, `pyqt5-dev` from Debian experimental. Then export `SIP_EXE=sip5` when building veusz.

It is a quick solution that allows to support both SIP v4 and v5. When SIP v4 support is no longer needed, it would be better to switch to `sipbuild` API as described in [SIP documentation](https://www.riverbankcomputing.com/static/Docs/sip/index.html).