### PR TITLE
Add setting to optionally omit import paths in document files

### DIFF
--- a/ui/preferences.ui
+++ b/ui/preferences.ui
@@ -172,6 +172,13 @@ Set to 0 to disable threads.</string>
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="docFileAddImportPaths">
+            <property name="text">
+             <string>Add import paths</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/veusz/dialogs/preferences.py
+++ b/veusz/dialogs/preferences.py
@@ -75,6 +75,9 @@ class PreferencesDialog(VeuszDialog):
         # use cwd for file dialogs
         (self.dirDocCWDRadio if setdb['dirname_usecwd'] else self.dirDocPrevRadio).click()
 
+        # add import paths
+        self.docFileAddImportPaths.setChecked( setdb['docfile_addimportpaths'] )
+
         # exporting documents
         {
             'doc': self.dirExportDocRadio,
@@ -203,6 +206,9 @@ class PreferencesDialog(VeuszDialog):
 
         # use cwd
         setdb['dirname_usecwd'] = self.dirDocCWDRadio.isChecked()
+        
+        # add import paths
+        setdb['docfile_addimportpaths'] = self.docFileAddImportPaths.isChecked()
 
         for radio, val in (
                 (self.dirExportDocRadio, 'doc'),

--- a/veusz/document/doc.py
+++ b/veusz/document/doc.py
@@ -405,7 +405,8 @@ class Document(qt.QObject):
         reldirname = None
         if getattr(fileobj, 'name', False):
             reldirname = os.path.dirname( os.path.abspath(fileobj.name) )
-            fileobj.write('AddImportPath(%s)\n' % utils.rrepr(reldirname))
+            if setting.settingdb['docfile_addimportpaths']:
+                fileobj.write('AddImportPath(%s)\n' % utils.rrepr(reldirname))
 
         # save those datasets which are linked
         # we do this first in case the datasets are overridden below

--- a/veusz/setting/settingdb.py
+++ b/veusz/setting/settingdb.py
@@ -80,6 +80,9 @@ defaultValues = {
     'export_template_single': '%DOCNAME%',
     'export_template_multi': '%DOCNAME%_%PAGE00%',
 
+    # add import paths
+    'docfile_addimportpaths': True,
+
     # ask tutorial before?
     'ask_tutorial': False,
 


### PR DESCRIPTION
I frequently store veusz files in git repositories.  For that, I do not like it if absolute paths are stored within them.  This branch adds an option in the preferences diaglogue to optionally *not* store import paths in the files.  It defaults to True in line with the current upstream behavior.