### PR TITLE
Minor fixes for api.rst

### DIFF
--- a/Documents/manual-source/api.rst
+++ b/Documents/manual-source/api.rst
@@ -1429,11 +1429,11 @@ example).
     To('graph1')
     Add('axis', name='x')
     To('x')
-    Set('label', '\\\\italic{x}')
+    Set('label', '\\italic{x}')
     To('..')
     Add('axis', name='y')
     To('y')
-    Set('label', 'sin \\\\italic{x}')
+    Set('label', 'sin \\italic{x}')
     Set('direction', 'vertical')
     To('..')
     Add('xy', name='xy1')
@@ -1458,8 +1458,9 @@ example).
     # note: autoAdd=False stops graph automatically adding own axes (used in saved files)
     graph = page.Add('graph', autoadd=False)
     x = graph.Add('axis', name='x')
-    x.label.val = '\\\\italic{x}'
+    x.label.val = '\\italic{x}'
     y = graph.Add('axis', name='y')
+    y.label.val = 'sin \\italic{x}'
     y.direction.val = 'vertical'
     xy = graph.Add('xy')
     xy.MarkerFill.color.val = 'cyan'


### PR DESCRIPTION
Some small fixes for the two Python code blocks in the API doc page, section on Translating old to new style.

Maybe in an older version of the docs or Sphinx the quadruple backslashes were necessary, but now all four are passing into both the compiled [HTML](https://veusz.github.io/docs/manual/api.html#non-qt-python-programs) and [PDF](https://veusz.github.io/docs/manual.pdf) versions of docs, when only two backslashes are wanted.

The second fix is adding the y axis label, which was missed from the new style code block.

p.s. Thanks ever so much for developing Veusz. I've used it for many years and think it's fantastic. 