### PR TITLE
Bugfix for boxplot

### DIFF
--- a/veusz/widgets/boxplot.py
+++ b/veusz/widgets/boxplot.py
@@ -87,7 +87,7 @@ class _Stats(object):
             iqr = self.topquart - self.botquart
             eltop = N.searchsorted(cleaned, self.topquart+1.5*iqr)-1
             self.topwhisker = cleaned[eltop]
-            elbot = max(N.searchsorted(cleaned, self.botquart-1.5*iqr)-1, 0)
+            elbot = max(N.searchsorted(cleaned, self.botquart-1.5*iqr), 0)
             self.botwhisker = cleaned[elbot]
         elif whiskermode == '1 stddev':
             stddev = N.std(cleaned)


### PR DESCRIPTION
Fixed calculation of bottom whisker in '1.5IQR' mode. Now effectivly
rounding up instead of down.

Closes #449 