### PR TITLE
Sort input file list

### DIFF
--- a/pyqtdistutils.py
+++ b/pyqtdistutils.py
@@ -281,7 +281,7 @@ class build_ext(distutils.command.build_ext.build_ext):
                 self._sip_compile(sip_exe, sip_dir, sip, sip_builddir)
             out = [
                 os.path.join(sip_builddir, fn)
-                for fn in os.listdir(sip_builddir)
+                for fn in sorted(os.listdir(sip_builddir))
                 if fn.endswith(".cpp")
             ]
             generated_sources.extend(out)


### PR DESCRIPTION
Sort input file list
so that `veusz/helpers/qtloops.cpython-38-x86_64-linux-gnu.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.