### PR TITLE
Move all hide checkboxes to top

### DIFF
--- a/veusz/setting/collections.py
+++ b/veusz/setting/collections.py
@@ -58,7 +58,8 @@ class Line(Settings):
         self.add( setting.Bool(
             'hide', False,
             descr = _('Hide the line'),
-            usertext = _('Hide')) )
+            usertext = _('Hide')),
+            hidebox = True )
 
     def makeQPen(self, painter):
         '''Make a QPen from the settings (ignoring hide).
@@ -135,11 +136,13 @@ class ErrorBarLine(Line):
         self.add( setting.Bool(
             'hideHorz', False,
             descr = _('Hide horizontal errors'),
-            usertext = _('Hide horz.')) )
+            usertext = _('Hide horz.')),
+            hidebox = True )
         self.add( setting.Bool(
             'hideVert', False,
             descr = _('Hide vertical errors'),
-            usertext=_('Hide vert.')) )
+            usertext=_('Hide vert.')),
+            hidebox = True )
 
 class Brush(Settings):
     '''Settings of a fill.'''
@@ -164,7 +167,8 @@ class Brush(Settings):
         self.add( setting.Bool(
             'hide', False,
             descr = _('Hide the fill'),
-            usertext = _('Hide')) )
+            usertext = _('Hide')),
+            hidebox = True )
 
     def makeQBrush(self, painter):
         '''Make a QBrush from the settings.'''
@@ -198,7 +202,8 @@ class BrushExtended(Settings):
         self.add( setting.Bool(
                 'hide', False,
                 descr = _('Hide the fill'),
-                usertext=_('Hide')) )
+                usertext=_('Hide')),
+                hidebox = True )
 
         self.add( setting.Int(
                 'transparency', 0,
@@ -231,7 +236,8 @@ class BrushExtended(Settings):
         self.add( setting.Bool(
                 'backhide', True,
                 descr = _('Hide hatch or pattern background'),
-                usertext=_('Back hide')) )
+                usertext=_('Back hide')),
+                hidebox = True )
 
 class KeyBrush(BrushExtended):
     '''Fill used for back of key.'''
@@ -289,7 +295,8 @@ class PointFill(BrushExtended):
         self.add( setting.Bool(
             'hideerror', False,
             descr = _('Hide the filled region inside the error bars'),
-            usertext=_('Hide error fill')) )
+            usertext=_('Hide error fill')),
+            hidebox = True )
 
 class ShapeFill(BrushExtended):
     '''Filling used for filling shapes.'''
@@ -349,7 +356,8 @@ class Text(Settings):
         self.add( setting.Bool(
             'hide', False,
             descr = _('Hide the text'),
-            usertext = _('Hide')) )
+            usertext = _('Hide')),
+            hidebox = True )
 
     def copy(self):
         """Make copy of settings."""
@@ -460,7 +468,8 @@ class Line3D(Settings):
         self.add( setting.Bool(
             'hide', False,
             descr = _('Hide the line'),
-            usertext=_('Hide')) )
+            usertext=_('Hide')),
+            hidebox = True )
 
     def makeLineProp(self, painter):
         """Construct line properties object for assigning to 3D object."""
@@ -509,7 +518,8 @@ class Surface3D(Settings):
         self.add( setting.Bool(
             'hide', False,
             descr = _('Hide surface'),
-            usertext=_('Hide')) )
+            usertext=_('Hide')),
+            hidebox = True )
 
     def makeSurfaceProp(self, painter):
         """Properties to assign to surface."""
@@ -565,11 +575,13 @@ class LineGrid3D(Line3D):
         self.add( setting.Bool(
             'hidehorz', False,
             descr = _('Hide horizontal lines'),
-            usertext=_('Hide horz.')) )
+            usertext=_('Hide horz.')),
+            hidebox = True )
         self.add( setting.Bool(
             'hidevert', False,
             descr = _('Hide vertical lines'),
-            usertext=_('Hide vert.')) )
+            usertext=_('Hide vert.')),
+            hidebox = True )
 
 class Lighting3D(Settings):
     '''Lighting options.'''

--- a/veusz/widgets/axisbroken.py
+++ b/veusz/widgets/axisbroken.py
@@ -58,7 +58,7 @@ class AxisBroken(axis.Axis):
                 [],
                 descr = _('Pairs of values to start and stop breaks'),
                 usertext = _('Break pairs'),
-                ), 4 )
+                ), posn = 4 )
         s.add( setting.FloatList(
                 'breakPosns',
                 [],

--- a/veusz/widgets/axisfunction.py
+++ b/veusz/widgets/axisfunction.py
@@ -191,21 +191,21 @@ class AxisFunction(axis.Axis):
                 settingsfalse=('min', 'max'),
                 settingstrue=('linkedaxis',),
                 descr=_('Link axis to another axis'),
-                usertext=_('Linked') ), 0 )
+                usertext=_('Linked') ), posn = 0 )
 
         s.add( setting.Str('function', 't',
                            descr=_('Monotonic function (use t as variable)'),
-                           usertext=_('Function')), 1 )
+                           usertext=_('Function')), posn = 1 )
         s.add( setting.Axis('linkedaxis', '', 'both',
                             descr =
                             _('Axis which this axis is based on'),
-                            usertext=_('Linked axis')), 6 )
+                            usertext=_('Linked axis')), posn = 6 )
         s.add( setting.FloatOrAuto('mint', 'Auto',
                                    descr=_('Minimum value of t or Auto'),
-                                   usertext=('Min t')), 7 )
+                                   usertext=('Min t')), posn = 7 )
         s.add( setting.FloatOrAuto('maxt', 'Auto',
                                    descr=_('Maximum value of t or Auto'),
-                                   usertext=('Max t')), 8 )
+                                   usertext=('Max t')), posn = 8 )
 
         s.get('autoRange').hidden = True
         s.get('autoRange').newDefault('exact')

--- a/veusz/widgets/bar.py
+++ b/veusz/widgets/bar.py
@@ -47,7 +47,7 @@ class BarLine(setting.Settings):
         setting.Settings.__init__(self, name, **args)
         self.add( setting.LineSet('lines',
                                   [('solid', '0.5pt', 'black', False)],
-                                  descr = _('Line styles for dataset bars'), 
+                                  descr = _('Line styles for dataset bars'),
                                   usertext=_('Line styles')) )
 
 def extend1DArray(array, length, missing=0.):
@@ -77,28 +77,28 @@ class BarPlotter(GenericPlotter):
 
         s.add( setting.Strings('keys', ('',),
                                descr=_('Key text for each dataset'),
-                               usertext=_('Key text')), 0)
+                               usertext=_('Key text')), posn = 0)
 
         s.add( setting.DatasetOrStr('labels', '',
                                     descr=_('Dataset or string to label bars'),
-                                    usertext=_('Labels')), 5 )
+                                    usertext=_('Labels')), posn = 5 )
 
         s.add( setting.Choice('mode', ('grouped', 'stacked', 'stacked-area'),
                               'grouped',
                               descr=_('Show datasets grouped '
                                       'together or as a single bar'),
-                              usertext=_('Mode')), 0)
+                              usertext=_('Mode')), posn = 0)
         s.add( setting.Choice('direction',
-                              ('horizontal', 'vertical'), 'vertical', 
+                              ('horizontal', 'vertical'), 'vertical',
                               descr = _('Horizontal or vertical bar chart'),
-                              usertext=_('Direction')), 0 )
+                              usertext=_('Direction')), posn = 0 )
         s.add( setting.DatasetExtended('posn', '',
                                        descr = _('Position of bars, dataset '
                                                  ' or expression (optional)'),
-                                       usertext=_('Positions')), 0 )
+                                       usertext=_('Positions')), posn = 0 )
         s.add( setting.Datasets('lengths', ('y',),
                                 descr = _('Datasets containing lengths of bars'),
-                                usertext=_('Lengths')), 0 )
+                                usertext=_('Lengths')), posn = 0 )
 
         s.add( setting.Float('barfill', 0.75,
                              minval = 0., maxval = 1.,
@@ -134,7 +134,7 @@ class BarPlotter(GenericPlotter):
         """User-friendly description."""
 
         s = self.settings
-        return _("lengths='%s', position='%s'") % (', '.join(s.lengths), 
+        return _("lengths='%s', position='%s'") % (', '.join(s.lengths),
                                                    s.posn)
 
     def affectsAxisRange(self):
@@ -158,7 +158,7 @@ class BarPlotter(GenericPlotter):
                 p = N.arange( max([len(d.data) for d in lengths]) )+1.
             else:
                 p = positions.data
-            
+
             return (labels, p)
 
         else:
@@ -171,7 +171,7 @@ class BarPlotter(GenericPlotter):
         for data in czip(*[ds.data for ds in datasets]):
             totpos = sum( [d for d in data if d > 0] )
             totneg = sum( [d for d in data if d < 0] )
-            
+
             minv = min(minv, totneg)
             maxv = max(maxv, totpos)
         return minv,  maxv
@@ -340,7 +340,7 @@ class BarPlotter(GenericPlotter):
             # convert bar length to plotter coords
             lengthcoord = axes[not ishorz].dataToPlotterCoords(
                 widgetposn, dataset['data'])
- 
+
             # these are the coordinates perpendicular to the bar
             posns1 = posns + (-usablewidth*0.5 + bardelta*dsnum +
                               (bardelta-barwidth)*0.5)
@@ -531,7 +531,7 @@ class BarPlotter(GenericPlotter):
         # where the bars are to be placed horizontally
         barposns, maxwidth = self.findBarPositions(
             lengths, positions, axes, widgetposn)
-        
+
         # only use finite positions
         origposnlen = len(barposns)
         validposn = N.isfinite(barposns)

--- a/veusz/widgets/boxplot.py
+++ b/veusz/widgets/boxplot.py
@@ -79,7 +79,7 @@ class _Stats(object):
         self.botquart = percentile(cleaned, 25)
         self.topquart = percentile(cleaned, 75)
         self.mean = N.mean(cleaned)
-        
+
         if whiskermode == 'min/max':
             self.botwhisker = cleaned.min()
             self.topwhisker = cleaned.max()
@@ -118,60 +118,60 @@ class BoxPlot(GenericPlotter):
         GenericPlotter.addSettings(s)
 
         s.remove('key')
-        s.add( setting.Choice('whiskermode', 
+        s.add( setting.Choice('whiskermode',
                               ('min/max',
                                '1.5IQR',
                                '1 stddev',
                                '9/91 percentile',
                                '2/98 percentile'),
-                              '1.5IQR', 
-                              descr = _('Whisker mode'), 
-                              usertext=_('Whisker mode')), 0 )
+                              '1.5IQR',
+                              descr = _('Whisker mode'),
+                              usertext=_('Whisker mode')), posn = 0 )
 
-        s.add( setting.Choice('direction', 
-                              ('horizontal', 'vertical'), 'vertical', 
-                              descr = _('Horizontal or vertical boxes'), 
-                              usertext=_('Direction')), 0 )
+        s.add( setting.Choice('direction',
+                              ('horizontal', 'vertical'), 'vertical',
+                              descr = _('Horizontal or vertical boxes'),
+                              usertext=_('Direction')), posn = 0 )
         s.add( setting.DatasetOrStr('labels', '',
                                     descr=_('Dataset or string to label bars'),
-                                    usertext=_('Labels')), 0 )
+                                    usertext=_('Labels')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'posn', '',
                 descr = _('Dataset or list of values giving '
                           'positions of boxes (optional)'),
-                usertext=_('Positions')), 0 )
+                usertext=_('Positions')), posn = 0 )
 
         # calculate statistics from these datasets
         s.add( setting.Datasets('values', ('data',),
                                 descr = _('Datasets containing values to '
                                           'calculate statistics for'),
-                                usertext=_('Datasets')), 0 )
+                                usertext=_('Datasets')), posn = 0 )
 
         # alternate mode where data are provided for boxes
         s.add( setting.DatasetExtended(
                 'whiskermax', '',
                 descr=_('Dataset with whisker maxima or list of values'),
-                usertext=_('Whisker max')), 0 )
+                usertext=_('Whisker max')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'whiskermin', '',
                 descr=_('Dataset with whisker minima or list of values'),
-                usertext=_('Whisker min')), 0 )
+                usertext=_('Whisker min')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'boxmax', '',
                 descr=_('Dataset with box maxima or list of values'),
-                usertext=_('Box max')), 0 )
+                usertext=_('Box max')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'boxmin', '',
                 descr=_('Dataset with box minima or list of values'),
-                usertext=_('Box min')), 0 )
+                usertext=_('Box min')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'median', '',
                 descr=_('Dataset with medians or list of values'),
-                usertext=_('Median')), 0 )
+                usertext=_('Median')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'mean', '',
                 descr=_('Dataset with means or list of values'),
-                usertext=_('Mean')), 0 )
+                usertext=_('Mean')), posn = 0 )
 
         # switch between different modes
         s.add( setting.BoolSwitch('calculate', True,
@@ -181,7 +181,7 @@ class BoxPlot(GenericPlotter):
                                   settingstrue=('whiskermode', 'values'),
                                   settingsfalse=('boxmin', 'whiskermin',
                                                  'boxmax', 'whiskermax',
-                                                 'mean', 'median')), 0 )
+                                                 'mean', 'median')), posn = 0 )
 
         # formatting options
         s.add( setting.Float('fillfraction', 0.75,

--- a/veusz/widgets/colorbar.py
+++ b/veusz/widgets/colorbar.py
@@ -54,7 +54,7 @@ class ColorBar(axis.Axis):
         s.add( setting.WidgetChoice('widgetName', '',
                                     descr=_('Corresponding widget'),
                                     widgettypes=('image', 'xy', 'nonorthpoint'),
-                                    usertext = _('Widget')), 0 )
+                                    usertext = _('Widget')), posn = 0 )
 
         s.get('log').readonly = True
         s.get('datascale').readonly = True
@@ -77,7 +77,7 @@ class ColorBar(axis.Axis):
                                       descr = _('Height of colorbar'),
                                       usertext=_('Height'),
                                       formatting=True) )
-        
+
         s.add( setting.Float( 'horzManual',
                               0.,
                               descr = _('Manual horizontal fractional position'),

--- a/veusz/widgets/contour.py
+++ b/veusz/widgets/contour.py
@@ -200,50 +200,50 @@ class Contour(plotters.GenericPlotter):
             dimensions = 2,
             descr = _('Dataset to plot'),
             usertext=_('Dataset')),
-               0 )
+               posn = 0 )
         s.add( setting.FloatOrAuto(
             'min', 'Auto',
             descr = _('Minimum value of contour scale'),
             usertext=_('Min. value')),
-               1 )
+               posn = 1 )
         s.add( setting.FloatOrAuto(
             'max', 'Auto',
             descr = _('Maximum value of contour scale'),
             usertext=_('Max. value')),
-               2 )
+               posn = 2 )
         s.add( setting.Int(
             'numLevels', 5,
             minval = 1,
             descr = _('Number of contour levels to plot'),
             usertext=_('Number levels')),
-               3 )
+               posn = 3 )
         s.add( setting.Choice(
             'scaling',
             ['linear', 'sqrt', 'log', 'squared', 'manual'],
             'linear',
             descr = _('Scaling between contour levels'),
             usertext=_('Scaling')),
-               4 )
+               posn = 4 )
         s.add( setting.FloatList(
             'manualLevels',
             [],
             descr = _('Levels to use for manual scaling'),
             usertext=_('Manual levels')),
-               5 )
+               posn = 5 )
 
         s.add( setting.Bool(
             'keyLevels',
             False,
             descr=_('Show levels in key'),
             usertext=_('Levels in key')),
-               6 )
+               posn = 6 )
 
         s.add( setting.FloatList(
             'levelsOut',
             [],
             descr = _('Levels used in the plot'),
             usertext=_('Output levels')),
-               7, readonly=True )
+               posn = 7, readonly=True )
 
         s.add( ContourLabel(
             'ContourLabels',

--- a/veusz/widgets/contour.py
+++ b/veusz/widgets/contour.py
@@ -102,7 +102,8 @@ class ContourFills(setting.Settings):
             'hide', False,
             descr = _('Hide fills'),
             usertext = _('Hide'),
-            formatting = True) )
+            formatting = True),
+            hidebox = True )
 
 class ContourLines(setting.Settings):
     """Settings for contour lines."""
@@ -118,7 +119,8 @@ class ContourLines(setting.Settings):
             'hide', False,
             descr = _('Hide lines'),
             usertext = _('Hide'),
-            formatting = True) )
+            formatting = True),
+            hidebox = True )
 
 class SubContourLines(setting.Settings):
     """Sub-dividing contour line settings."""
@@ -140,7 +142,8 @@ class SubContourLines(setting.Settings):
             'hide', True,
             descr=_('Hide lines'),
             usertext=_('Hide'),
-            formatting=True) )
+            formatting=True),
+            hidebox = True )
 
 class ContourLabel(setting.Text):
     """For tick labels on axes."""

--- a/veusz/widgets/covariance.py
+++ b/veusz/widgets/covariance.py
@@ -68,28 +68,28 @@ class Covariance(plotters.GenericPlotter):
         s.add( setting.DatasetExtended(
             'covyy', '',
             descr=_('Covariance matrix entry (Y,Y) [computed from data if blank]'),
-            usertext=_('Cov(Y,Y)')), 0 )
+            usertext=_('Cov(Y,Y)')), posn = 0 )
         s.add( setting.DatasetExtended(
             'covxy', '',
             descr=_('Covariance matrix entry (X,Y) [computed from data if blank]'),
-            usertext=_('Cov(X,Y)')), 0 )
+            usertext=_('Cov(X,Y)')), posn = 0 )
         s.add( setting.DatasetExtended(
             'covyx', '',
             descr=_('Covariance matrix entry (Y,X) [computed from data if blank]'),
-            usertext=_('Cov(Y,X)')), 0 )
+            usertext=_('Cov(Y,X)')), posn = 0 )
         s.add( setting.DatasetExtended(
             'covxx', '',
             descr=_('Covariance matrix entry (X,X) [computed from data if blank]'),
-            usertext=_('Cov(X,X)')), 0 )
+            usertext=_('Cov(X,X)')), posn = 0 )
 
         s.add( setting.DatasetExtended(
             'yData', 'y',
             descr=_('Y values, given by dataset, expression or list of values'),
-            usertext=_('Y data')), 0 )
+            usertext=_('Y data')), posn = 0 )
         s.add( setting.DatasetExtended(
             'xData', 'x',
             descr=_('X values, given by dataset, expression or list of values'),
-            usertext=_('X data')), 0 )
+            usertext=_('X data')), posn = 0 )
 
         s.add( CovarianceLine(
             'Line',

--- a/veusz/widgets/fit.py
+++ b/veusz/widgets/fit.py
@@ -138,47 +138,47 @@ class Fit(FunctionPlotter):
                 'values',
                 {'a': 0.0, 'b': 1.0},
                 descr = _('Variables and fit values'),
-                usertext=_('Parameters')), 1 )
+                usertext=_('Parameters')), posn = 1 )
         s.add( setting.DatasetExtended(
                 'xData', 'x',
                 descr = _('X data to fit (dataset name, list of values '
                           'or expression)'),
-                usertext=_('X data')), 2 )
+                usertext=_('X data')), posn = 2 )
         s.add( setting.DatasetExtended(
                 'yData', 'y',
                 descr = _('Y data to fit (dataset name, list of values '
                           'or expression)'),
-                usertext=_('Y data')), 3 )
+                usertext=_('Y data')), posn = 3 )
         s.add( setting.Bool(
                 'fitRange', False,
                 descr = _('Fit only the data between the '
                           'minimum and maximum of the axis for '
                           'the function variable'),
                 usertext=_('Fit only range')),
-               4 )
+               posn = 4 )
         s.add( setting.WidgetChoice(
                 'outLabel', '',
                 descr=_('Write best fit parameters to this text label '
                         'after fitting'),
                 widgettypes=('label',),
                 usertext=_('Output label')),
-               5 )
+               posn = 5 )
         s.add( setting.Str('outExpr', '',
                            descr = _('Output best fitting expression'),
                            usertext=_('Output expression')),
-               6, readonly=True )
+               posn = 6, readonly=True )
         s.add( setting.Float('chi2', -1,
                              descr = 'Output chi^2 from fitting',
                              usertext=_('Fit &chi;<sup>2</sup>')),
-               7, readonly=True )
+               posn = 7, readonly=True )
         s.add( setting.Int('dof', -1,
                            descr = _('Output degrees of freedom from fitting'),
                            usertext=_('Fit d.o.f.')),
-               8, readonly=True )
+               posn = 8, readonly=True )
         s.add( setting.Float('redchi2', -1,
                              descr = _('Output reduced-chi-squared from fitting'),
                              usertext=_('Fit reduced &chi;<sup>2</sup>')),
-               9, readonly=True )
+               posn = 9, readonly=True )
 
         f = s.get('function')
         f.newDefault('a + b*x')

--- a/veusz/widgets/function.py
+++ b/veusz/widgets/function.py
@@ -52,16 +52,16 @@ class FunctionPlotter(GenericPlotter):
             minval = 3,
             descr = _('Number of steps to evaluate the function'
                       ' over'),
-            usertext=_('Steps'), formatting=True), 0 )
+            usertext=_('Steps'), formatting=True), posn = 0 )
         s.add( setting.Choice(
             'variable', ['x', 'y'], 'x',
             descr=_('Variable the function is a function of'),
             usertext=_('Variable')),
-               0 )
+               posn = 0 )
         s.add( setting.Str(
             'function', 'x',
             descr=_('Function expression'),
-            usertext=_('Function')), 0 )
+            usertext=_('Function')), posn = 0 )
 
         s.add(setting.FloatOrAuto(
             'min', 'Auto',

--- a/veusz/widgets/function3d.py
+++ b/veusz/widgets/function3d.py
@@ -125,31 +125,31 @@ class Function3D(plotters3d.GenericPlotter3D):
             'x,y,z=fns(t)',
             descr=_('Type of function to plot'),
             usertext=_('Mode'),
-            showfn=klass._fnsetnshowhide), 0)
+            showfn=klass._fnsetnshowhide), posn = 0)
 
         s.add(setting.Str(
             'fnx', '',
             descr=_('Function for x coordinate'),
-            usertext=_('X function') ), 1)
+            usertext=_('X function') ), posn = 1)
         s.add(setting.Str(
             'fny', '',
             descr=_('Function for y coordinate'),
-            usertext=_('Y function') ), 2)
+            usertext=_('Y function') ), posn = 2)
         s.add(setting.Str(
             'fnz', '',
             descr=_('Function for z coordinate'),
-            usertext=_('Z function') ), 3)
+            usertext=_('Z function') ), posn = 3)
         s.add(setting.Str(
             'fncolor', '',
             descr=_('Function to give color (0-1)'),
-            usertext=_('Color function') ), 4)
+            usertext=_('Color function') ), posn = 4)
 
         s.add( setting.Color(
             'color',
             'auto',
             descr = _('Master color'),
             usertext = _('Color'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add(FunctionLine(
             'Line',
             descr = _('Line settings'),

--- a/veusz/widgets/histo.py
+++ b/veusz/widgets/histo.py
@@ -190,7 +190,7 @@ class FillBrush1(setting.BrushExtended):
             ('under', 'over', 'tozero'),
             'tozero',
             descr=_('Mode'),
-            usertext=_('Mode')), 0)
+            usertext=_('Mode')), posn = 0)
         self.add( setting.Bool(
             'hideerror', False,
             descr = _('Hide the filled region inside the error bars'),
@@ -248,12 +248,12 @@ class Histo(GenericPlotter):
         s.add( setting.DatasetExtended(
             'data', '',
             descr=_('Dataset to apply binning to'),
-            usertext=_('Bin dataset')), 1 )
+            usertext=_('Bin dataset')), posn = 1 )
 
         s.add( setting.DatasetExtended(
             'weights', '',
             descr=_('Optional weight applied to counts of data'),
-            usertext=_('Weights')), 3 )
+            usertext=_('Weights')), posn = 3 )
 
         s.add( setting.Choice(
             'calcmode',
@@ -264,7 +264,7 @@ class Histo(GenericPlotter):
             ),
             'counts',
             descr=_('Calculate when binning'),
-            usertext=_('Calculate')), 4 )
+            usertext=_('Calculate')), posn = 4 )
 
         s.add( setting.ChoiceSwitch(
             'binning',
@@ -274,76 +274,76 @@ class Histo(GenericPlotter):
             'constant',
             showfn=klass._showbinning,
             descr=_('Binning mode'),
-            usertext=_('Binning')), 5 )
+            usertext=_('Binning')), posn = 5 )
 
         s.add( setting.FloatOrAuto(
             'minval', 'Auto',
             descr=_('Minimum of range'),
-            usertext=_('Minimum')), 6 )
+            usertext=_('Minimum')), posn = 6 )
         s.add( setting.FloatOrAuto(
             'maxval', 'Auto',
             descr=_('Maximum of range'),
-            usertext=_('Maximum')), 7 )
+            usertext=_('Maximum')), posn = 7 )
 
         s.add( setting.ChoiceSwitch(
             'scaling',
             ('linear', 'log', 'sqrt', 'arcsinh', 'exp', 'sqr', 'sinh'),
             'linear',
             descr=_('Data scaling before creating bins'),
-            usertext=_('Bin scaling')), 9 )
+            usertext=_('Bin scaling')), posn = 9 )
         s.add( setting.Int(
             'numbins', 10,
             minval=1, maxval=100000,
             descr=_('Number of bins'),
-            usertext=_('Number')), 9 )
+            usertext=_('Number')), posn = 9 )
         s.add( setting.FloatList(
             'manual',
             [],
             descr=_('Manual binning edges'),
-            usertext=_('Manual')), 10 )
+            usertext=_('Manual')), posn = 10 )
 
         s.add( setting.Choice(
             'errormode',
             ('none', 'sqrt', 'gehrels'),
             'gehrels',
             descr=_('Error estimation'),
-            usertext=_('Uncertainty')), 11 )
+            usertext=_('Uncertainty')), posn = 11 )
 
         s.add( setting.Choice(
             'direction',
             ('horizontal', 'vertical'),
             'vertical',
             descr=_('Bars direction'),
-            usertext=_('Direction')), 12 )
+            usertext=_('Direction')), posn = 12 )
 
         s.add( setting.Color(
             'color',
             'auto',
             descr = _('Master color'),
             usertext = _('Color'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add( setting.Choice(
             'style',
             ('step', 'join'),
             'step',
             descr = _('Drawing style'),
             usertext = _('Style'),
-            formatting=True), 1 )
+            formatting=True), posn = 1 )
         s.add( setting.Marker(
             'marker',
             'none',
             descr = _('Type of marker to plot'),
-            usertext=_('Marker'), formatting=True), 2 )
+            usertext=_('Marker'), formatting=True), posn = 2 )
         s.add( setting.DistancePt(
             'markerSize',
             '3pt',
             descr = _('Size of marker to plot'),
-            usertext=_('Marker size'), formatting=True), 3 )
+            usertext=_('Marker size'), formatting=True), posn = 3 )
         s.add( setting.ErrorStyle(
             'errorStyle',
             'none',
             descr=_('Style of error bars to plot'),
-            usertext=_('Error style'), formatting=True), 4 )
+            usertext=_('Error style'), formatting=True), posn = 4 )
 
         s.add( PlotLine(
             'Line',

--- a/veusz/widgets/histo.py
+++ b/veusz/widgets/histo.py
@@ -194,7 +194,8 @@ class FillBrush1(setting.BrushExtended):
         self.add( setting.Bool(
             'hideerror', False,
             descr = _('Hide the filled region inside the error bars'),
-            usertext=_('Hide error fill')) )
+            usertext=_('Hide error fill')),
+            hidebox = True )
 
 class FillBrush2(FillBrush1):
     def __init__(self, name, **args):

--- a/veusz/widgets/image.py
+++ b/veusz/widgets/image.py
@@ -155,31 +155,31 @@ class Image(plotters.GenericPlotter):
             dimensions = 2,
             descr = _('Dataset to plot'),
             usertext=_('Dataset')),
-               0 )
+               posn = 0 )
         s.add( setting.FloatOrAuto(
             'min', 'Auto',
             descr = _('Minimum value of image scale'),
             usertext=_('Min. value')),
-               1 )
+               posn = 1 )
         s.add( setting.FloatOrAuto(
             'max', 'Auto',
             descr = _('Maximum value of image scale'),
             usertext=_('Max. value')),
-               2 )
+               posn = 2 )
         s.add( setting.Choice(
             'colorScaling',
             ['linear', 'sqrt', 'log', 'squared'],
             'linear',
             descr = _('Scaling to transform numbers to color'),
             usertext=_('Scaling')),
-               3 )
+               posn = 3 )
 
         s.add( setting.DatasetExtended(
             'transparencyData', '',
             dimensions = 2,
             descr = _('Dataset to use for transparency (0 to 1)'),
             usertext=_('Trans. data')),
-               4 )
+               posn = 4 )
 
         s.add( setting.Choice(
             'mapping',
@@ -187,7 +187,7 @@ class Image(plotters.GenericPlotter):
             'pixels',
             descr = _('Map image using pixels or bound coordinates'),
             usertext=_('Mapping')),
-               5 )
+               posn = 5 )
 
         s.add( setting.Colormap(
             'colorMap',
@@ -195,13 +195,13 @@ class Image(plotters.GenericPlotter):
             descr = _('Set of colors to plot data with'),
             usertext=_('Colormap'),
             formatting=True),
-               5 )
+               posn = 5 )
         s.add( setting.Bool(
             'colorInvert', False,
             descr = _('Invert color map'),
             usertext=_('Invert colormap'),
             formatting=True),
-               6 )
+               posn = 6 )
         s.add( setting.Int(
             'transparency', 0,
             descr = _('Transparency percentage'),
@@ -209,7 +209,7 @@ class Image(plotters.GenericPlotter):
             minval = 0,
             maxval = 100,
             formatting=True),
-               7 )
+               posn = 7 )
 
         s.add( setting.Choice(
             'drawMode',

--- a/veusz/widgets/key.py
+++ b/veusz/widgets/key.py
@@ -191,7 +191,7 @@ class Key(widget.Widget):
         s.add( setting.Str(
             'title', '',
             descr=_('Key title text'),
-            usertext=_('Title')), 0 )
+            usertext=_('Title')), posn = 0 )
 
         s.add( setting.KeyBrush(
             'Background',

--- a/veusz/widgets/line.py
+++ b/veusz/widgets/line.py
@@ -62,40 +62,40 @@ class Line(plotters.FreePlotter):
                     'first and second points'),
             usertext=_('Mode'),
             formatting=False,
-            showfn=klass.showOrHideSetn), 0)
+            showfn=klass.showOrHideSetn), posn = 0)
 
         s.add( setting.DatasetExtended(
             'length',
             [0.2],
             descr=_('List of fractional lengths, dataset or expression'),
             usertext=_('Lengths'),
-            formatting=False), 4 )
+            formatting=False), posn = 4 )
         s.add( setting.DatasetExtended(
             'angle',
             [0.],
             descr=_('List of angle of lines, dataset or expression '
                     '(degrees)'),
             usertext=_('Angles'),
-            formatting=False), 5 )
+            formatting=False), posn = 5 )
         s.add( setting.DatasetExtended(
             'xPos2',
             [1.],
             descr=_('List of fractional X coordinates, dataset or '
                     'expression for point 2'),
             usertext=_('X positions 2'),
-            formatting=False), 6 )
+            formatting=False), posn = 6 )
         s.add( setting.DatasetExtended(
             'yPos2',
             [1.],
             descr=_('List of fractional Y coordinates, dataset or '
                     'expression for point 2'),
             usertext=_('Y positions 2'),
-            formatting=False), 7 )
+            formatting=False), posn = 7 )
 
         s.add( setting.Bool('clip', False,
                             descr=_('Clip line to its container'),
                             usertext=_('Clip'),
-                            formatting=True), 0 )
+                            formatting=True), posn = 0 )
 
         s.add( setting.Line('Line',
                             descr = _('Line style'),
@@ -108,13 +108,13 @@ class Line(plotters.FreePlotter):
 
         s.add( setting.DistancePt('arrowSize', '5pt',
                                   descr = _('Size of arrow to plot'),
-                                  usertext=_('Arrow size'), formatting=True), 0)
+                                  usertext=_('Arrow size'), formatting=True), posn = 0)
         s.add( setting.Arrow('arrowright', 'none',
                              descr = _('Arrow to plot on right side'),
-                             usertext=_('Arrow right'), formatting=True), 0)
+                             usertext=_('Arrow right'), formatting=True), posn = 0)
         s.add( setting.Arrow('arrowleft', 'none',
                              descr = _('Arrow to plot on left side'),
-                             usertext=_('Arrow left'), formatting=True), 0)
+                             usertext=_('Arrow left'), formatting=True), posn = 0)
 
     def _computeLinesLengthAngle(self, posn, lengthscaling):
         """Return set of lines to plot for length-angle."""
@@ -179,7 +179,7 @@ class Line(plotters.FreePlotter):
             return
 
         # if a dataset is used, we can't use control items
-        isnotdataset = ( not s.get('xPos').isDataset(d) and 
+        isnotdataset = ( not s.get('xPos').isDataset(d) and
                          not s.get('yPos').isDataset(d) )
 
         if s.mode == 'length-angle':

--- a/veusz/widgets/nonorthfunction.py
+++ b/veusz/widgets/nonorthfunction.py
@@ -56,7 +56,7 @@ class NonOrthFunction(Widget):
         s.add(setting.FloatOrAuto('min', 'Auto',
                                   descr=_('Minimum value at which to plot function'),
                                   usertext=_('Min')))
-        
+
         s.add(setting.FloatOrAuto('max', 'Auto',
                                   descr=_('Maximum value at which to plot function'),
                                   usertext=_('Max')))
@@ -79,7 +79,7 @@ class NonOrthFunction(Widget):
         s.add( setting.Int('steps', 50,
                            descr = _('Number of steps to evaluate the function'
                                      ' over'),
-                           usertext=_('Steps'), formatting=True), 0 )
+                           usertext=_('Steps'), formatting=True), posn = 0 )
 
     @classmethod
     def allowedParentTypes(klass):

--- a/veusz/widgets/nonorthpoint.py
+++ b/veusz/widgets/nonorthpoint.py
@@ -75,15 +75,15 @@ class NonOrthPoint(Widget):
                              'auto',
                              descr = _('Master color'),
                              usertext = _('Color'),
-                             formatting=True), 0 )
+                             formatting=True), posn = 0 )
         s.add( setting.DistancePt('markerSize',
                                   '3pt',
                                   descr = _('Size of marker to plot'),
-                                  usertext=_('Marker size'), formatting=True), 0 )
+                                  usertext=_('Marker size'), formatting=True), posn = 0 )
         s.add( setting.Marker('marker',
                               'circle',
                               descr = _('Type of marker to plot'),
-                              usertext=_('Marker'), formatting=True), 0 )
+                              usertext=_('Marker'), formatting=True), posn = 0 )
         s.add( setting.Line('PlotLine',
                             descr = _('Plot line settings'),
                             usertext = _('Plot line')),

--- a/veusz/widgets/point.py
+++ b/veusz/widgets/point.py
@@ -358,20 +358,20 @@ class PointPlotter(GenericPlotter):
         s.add( setting.DatasetExtended(
             'yData', 'y',
             descr=_('Y values, given by dataset, expression or list of values'),
-            usertext=_('Y data')), 0 )
+            usertext=_('Y data')), posn = 0 )
         s.add( setting.DatasetExtended(
             'xData', 'x',
             descr=_('X values, given by dataset, expression or list of values'),
-            usertext=_('X data')), 0 )
+            usertext=_('X data')), posn = 0 )
         s.add( setting.DatasetOrStr(
             'labels', '',
             descr=_('Dataset or string to label points'),
-            usertext=_('Labels')), 5 )
+            usertext=_('Labels')), posn = 5 )
         s.add( setting.DatasetExtended(
             'scalePoints', '',
             descr = _('Scale size of markers given by dataset, expression'
                       ' or list of values'),
-            usertext=_('Scale markers')), 6 )
+            usertext=_('Scale markers')), posn = 6 )
 
         # formatting
         s.add( setting.Int(
@@ -379,30 +379,30 @@ class PointPlotter(GenericPlotter):
             minval=1,
             descr=_('Thin number of error bars plotted by this factor'),
             usertext=_('Thin errors'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add( setting.Int(
             'thinfactor', 1,
             minval=1,
             descr=_('Thin number of markers plotted'
                     ' for each datapoint by this factor'),
             usertext=_('Thin markers'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add( setting.Color(
             'color',
             'auto',
             descr = _('Master color'),
             usertext = _('Color'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add( setting.DistancePt(
             'markerSize',
             '3pt',
             descr = _('Size of marker to plot'),
-            usertext=_('Marker size'), formatting=True), 0 )
+            usertext=_('Marker size'), formatting=True), posn = 0 )
         s.add( setting.Marker(
             'marker',
             'circle',
             descr = _('Type of marker to plot'),
-            usertext=_('Marker'), formatting=True), 0 )
+            usertext=_('Marker'), formatting=True), posn = 0 )
         s.add( setting.DataColor('Color') )
 
         s.add( setting.ErrorStyle(

--- a/veusz/widgets/point3d.py
+++ b/veusz/widgets/point3d.py
@@ -67,7 +67,7 @@ class MarkerLine3D(setting.Line3D):
             'scale', True,
             descr=_('Scale border with marker size'),
             usertext=_('Scale'),
-            formatting=True), 4)
+            formatting=True), posn = 4)
 
 class ErrorLine3D(setting.Line3D):
     """Error bar line."""
@@ -89,46 +89,46 @@ class Point3D(plotters3d.GenericPlotter3D):
         s.add( setting.DatasetExtended(
                 'zData', 'z',
                 descr=_('Z values, given by dataset, expression or list of values'),
-                usertext=_('Z data')), 0 )
+                usertext=_('Z data')), posn = 0 )
         s.add( setting.DatasetExtended(
                'yData', 'y',
                 descr=_('Y values, given by dataset, expression or list of values'),
-                usertext=_('Y data')), 0 )
+                usertext=_('Y data')), posn = 0 )
         s.add( setting.DatasetExtended(
                 'xData', 'x',
                 descr=_('X values, given by dataset, expression or list of values'),
-                usertext=_('X data')), 0 )
+                usertext=_('X data')), posn = 0 )
         # s.add( setting.DatasetOrStr(
         #     'labels', '',
         #     descr=_('Dataset or string to label points'),
-        #     usertext=_('Labels')), 5 )
+        #     usertext=_('Labels')), posn = 5 )
         s.add( setting.DatasetExtended(
             'scalePoints', '',
             descr = _('Scale size of markers given by dataset, expression'
                       ' or list of values'),
-            usertext=_('Scale markers')), 6 )
+            usertext=_('Scale markers')), posn = 6 )
 
         s.add( setting.Bool(
             'scalePersp', True,
             descr=_('Scale marker size using perspective'),
             usertext=_('Perspective'),
-            formatting=True), 0)
+            formatting=True), posn = 0)
         s.add( setting.Float(
             'markerSize', 10,
             minval=0, maxval=1000,
             descr=_('Size of markers (relative to plot)'),
             usertext=_('Size'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add( setting.Color(
             'color',
             'auto',
             descr = _('Master color'),
             usertext = _('Color'),
-            formatting=True), 0 )
+            formatting=True), posn = 0 )
         s.add( setting.Marker(
             'marker', 'circle',
             descr = _('Type of marker to plot'),
-            usertext=_('Marker'), formatting=True), 0 )
+            usertext=_('Marker'), formatting=True), posn = 0 )
         s.add( setting.DataColor('Color') )
 
         s.add( PlotLine3D(

--- a/veusz/widgets/polar.py
+++ b/veusz/widgets/polar.py
@@ -113,11 +113,13 @@ class TickLabel(axis.TickLabel):
         self.add( setting.Bool(
             'hideradial', False,
             descr = _('Hide radial labels'),
-            usertext=_('Hide radial') ) )
+            usertext=_('Hide radial') ),
+            hidebox = True )
         self.add( setting.Bool(
             'hidetangential', False,
             descr = _('Hide spoke labels'),
-            usertext=_('Hide spokes') ) )
+            usertext=_('Hide spokes') ),
+            hidebox = True )
 
 class Polar(NonOrthGraph):
     '''Polar plotter.'''

--- a/veusz/widgets/shape.py
+++ b/veusz/widgets/shape.py
@@ -75,17 +75,17 @@ class BoxShape(Shape):
                 'width', [0.1],
                 descr=_('List of fractional widths, dataset or expression'),
                 usertext=_('Widths'),
-                formatting=False), 3 )
+                formatting=False), posn = 3 )
         s.add( setting.DatasetExtended(
                 'height', [0.1],
                 descr=_('List of fractional heights, dataset or expression'),
                 usertext=_('Heights'),
-                formatting=False), 4 )
+                formatting=False), posn = 4 )
         s.add( setting.DatasetExtended(
                 'rotate', [0.],
                 descr=_('Rotation angles of shape, dataset or expression'),
                 usertext=_('Rotate'),
-                formatting=False), 5 )
+                formatting=False), posn = 5 )
 
     def drawShape(self, painter, rect):
         pass

--- a/veusz/widgets/surface3d.py
+++ b/veusz/widgets/surface3d.py
@@ -62,16 +62,16 @@ class Surface3D(plotters3d.GenericPlotter3D):
             'z(x,y)',
             descr=_('Axes of plot surface'),
             usertext=_('Mode')),
-              0)
+              posn = 0)
         s.add(setting.DatasetExtended(
             'data', '',
             dimensions=2,
             descr=_('Dataset to plot'),
             usertext=_('Dataset')),
-              1)
+              posn = 1)
         s.add(setting.DataColor(
             'DataColor', dimensions=2),
-              2)
+              posn = 2)
 
         s.add(setting.Bool(
             'highres', False,

--- a/veusz/widgets/textlabel.py
+++ b/veusz/widgets/textlabel.py
@@ -56,35 +56,35 @@ class TextLabel(plotters.FreePlotter):
 
         s.add( setting.DatasetOrStr('label', '',
                                     descr=_('Text to show or text dataset'),
-                                    usertext=_('Label')), 0 )
+                                    usertext=_('Label')), posn = 0 )
 
         s.add( setting.AlignHorz('alignHorz',
                                  'left',
                                  descr=_('Horizontal alignment of label'),
                                  usertext=_('Horz alignment'),
-                                 formatting=True), 7)
+                                 formatting=True), posn = 7)
         s.add( setting.AlignVert('alignVert',
                                  'bottom',
                                  descr=_('Vertical alignment of label'),
                                  usertext=_('Vert alignment'),
-                                 formatting=True), 8)
+                                 formatting=True), posn = 8)
 
         s.add( setting.Float('angle', 0.,
                              descr=_('Angle of the label in degrees'),
                              usertext=_('Angle'),
-                             formatting=True), 9 )
+                             formatting=True), posn = 9 )
 
         s.add( setting.DistancePt(
                 'margin',
                 '4pt',
                 descr = _('Margin of fill/border'),
                 usertext=_('Margin'),
-                formatting=True), 10 )
+                formatting=True), posn = 10 )
 
         s.add( setting.Bool('clip', False,
                             descr=_('Clip text to its container'),
                             usertext=_('Clip'),
-                            formatting=True), 11 )
+                            formatting=True), posn = 11 )
 
         s.add( setting.Text('Text',
                             descr = _('Text settings'),

--- a/veusz/widgets/vectorfield.py
+++ b/veusz/widgets/vectorfield.py
@@ -51,61 +51,61 @@ class VectorField(plotters.GenericPlotter):
                 dimensions = 2,
                 descr = _('X coordinate length or vector magnitude'),
                 usertext = _('dx or r')),
-               0 )
+               posn = 0 )
         s.add( setting.DatasetExtended(
                 'data2', '',
                 dimensions = 2,
                 descr = _('Y coordinate length or vector angle'),
                 usertext = _('dy or theta')),
-               1 )
+               posn = 1 )
         s.add( setting.Choice('mode',
                               ['cartesian', 'polar'],
                               'cartesian',
                               descr = _('Cartesian (dx,dy) or polar (r,theta)'),
                               usertext = _('Mode')),
-               2 )
+               posn = 2 )
         s.add( setting.FloatChoice(
             'rotate',
             [0., 45., 90., 135., 180., -135., -90., -45.],
             0.,
             descr = _('Rotate vector clockwise by this angle in degrees'),
             usertext = _('Rotate')),
-               3 )
+               posn = 3 )
         s.add( setting.Bool(
             'reflectx', False,
             descr = _('Reflect vector in X direction'),
             usertext = _('Reflect X')),
-               4 )
+               posn = 4 )
         s.add( setting.Bool(
             'reflecty', False,
             descr = _('Reflect vector in Y direction'),
             usertext = _('Reflect Y')),
-               5 )
+               posn = 5 )
 
         # formatting
         s.add( setting.DistancePt('baselength', '10pt',
                                   descr = _('Base length of unit vector'),
                                   usertext = _('Base length'),
                                   formatting=True),
-               0 )
+               posn = 0 )
         s.add( setting.DistancePt('arrowsize', '2pt',
                                   descr = _('Size of any arrows'),
                                   usertext = _('Arrow size'),
                                   formatting=True),
-               1 )
+               posn = 1 )
         s.add( setting.Bool('scalearrow', True,
                             descr = _('Scale arrow head by length'),
                             usertext = _('Scale arrow'),
                             formatting=True),
-               2 )
+               posn = 2 )
         s.add( setting.Arrow('arrowfront', 'none',
                              descr = _('Arrow in front direction'),
                              usertext=_('Arrow front'), formatting=True),
-               3)
+               posn = 3)
         s.add( setting.Arrow('arrowback', 'none',
                              descr = _('Arrow in back direction'),
                              usertext=_('Arrow back'), formatting=True),
-               4)
+               posn = 4)
 
         s.add( setting.Line('Line',
                             descr = _('Line style'),
@@ -226,7 +226,7 @@ class VectorField(plotters.GenericPlotter):
             # this is backward - have to convert from dx, dy to angle, length
             angles = 180 - N.arctan2(dy, dx) * (180./N.pi)
             lengths = N.sqrt(dx**2+dy**2) * 2
-            
+
             # scale arrow heads by arrow length if requested
             if s.scalearrow:
                 arrowsizes = (arrowsize/baselength/2) * lengths
@@ -238,6 +238,6 @@ class VectorField(plotters.GenericPlotter):
                     utils.plotLineArrow(painter, x, y, l, a, asize,
                                         arrowleft=s.arrowfront,
                                         arrowright=s.arrowback)
-                
+
 # allow the factory to instantiate a vector field
 document.thefactory.register( VectorField )

--- a/veusz/widgets/volume3d.py
+++ b/veusz/widgets/volume3d.py
@@ -72,22 +72,22 @@ class Volume3D(plotters3d.GenericPlotter3D):
         s.add( setting.DatasetExtended(
             'transData', '',
             descr=_('Transparency dataset, optional, 0-1'),
-            usertext=_('Transparency')), 0 )
+            usertext=_('Transparency')), posn = 0 )
         s.add( setting.DatasetExtended(
             'zData', 'z',
             descr=_('Z dataset'),
-            usertext=_('Z data')), 0 )
+            usertext=_('Z data')), posn = 0 )
         s.add( setting.DatasetExtended(
             'yData', 'y',
             descr=_('Y dataset'),
-            usertext=_('Y data')), 0 )
+            usertext=_('Y data')), posn = 0 )
         s.add( setting.DatasetExtended(
             'xData', 'x',
             descr=_('X dataset'),
-            usertext=_('X data')), 0 )
+            usertext=_('X data')), posn = 0 )
         s.add(DataColor(
             'DataColor', dimensions=1),
-              0)
+              posn = 0)
 
         s.add(setting.Colormap(
             'colorMap',
@@ -95,13 +95,13 @@ class Volume3D(plotters3d.GenericPlotter3D):
             descr = _('Set of colors to plot data with'),
             usertext=_('Colormap'),
             formatting=True),
-            0)
+            posn = 0)
         s.add(setting.Bool(
             'colorInvert', False,
             descr = _('Invert color map'),
             usertext=_('Invert colormap'),
             formatting=True),
-            1)
+            posn = 1)
         s.add(setting.Int(
             'transparency', 50,
             descr = _('Transparency percentage'),
@@ -109,21 +109,21 @@ class Volume3D(plotters3d.GenericPlotter3D):
             minval = 0,
             maxval = 100,
             formatting=True),
-            2)
+            posn = 2)
         s.add(setting.Int(
             'reflectivity', 0,
             minval=0, maxval=100,
             descr=_('Reflectivity percentage'),
             usertext=_('Reflectivity'),
             formatting=True),
-            3)
+            posn = 3)
         s.add(setting.Float(
             'fillfactor', 1,
             minval=0, maxval=1,
             descr=_('Filling factor (0-1)'),
             usertext=_('Fill factor'),
             formatting=True),
-            4)
+            posn = 4)
 
         s.add(setting.Line3D(
             'Line',

--- a/veusz/widgets/widget.py
+++ b/veusz/widgets/widget.py
@@ -98,7 +98,7 @@ class Widget(object):
 
         # store child widgets
         self.children = []
-        
+
         # settings for widget
         self.settings = setting.Settings(
             'Widget_' + self.typename,
@@ -184,7 +184,7 @@ class Widget(object):
 
     def addChild(self, child, index=9999999):
         """Add child to list.
-        
+
         index is a position to place the new child
         """
         self.children.insert(index, child)
@@ -292,7 +292,7 @@ class Widget(object):
             # iterate over children in reverse order
             for c in reversed(self.children):
                 c.draw(bounds, painthelper, outerbounds=outerbounds)
- 
+
         # return our final bounds
         return bounds
 
@@ -395,7 +395,7 @@ class Widget(object):
 
     def updateControlItem(self, controlitem, pos):
         """Update the widget's control point.
-        
+
         controlitem is the control item in question."""
 
         pass

--- a/veusz/widgets/widget.py
+++ b/veusz/widgets/widget.py
@@ -121,7 +121,8 @@ class Widget(object):
         s.add( setting.Bool('hide', False,
                             descr = _('Hide object'),
                             usertext = _('Hide'),
-                            formatting = True) )
+                            formatting = True),
+               hidebox = True )
 
     def getDocument(self):
         """Return document.


### PR DESCRIPTION
This PR is born out of a personal frustration: I often check the effect of a setting by hiding/unhiding the widget. For this to work effectively, the hide checkbox should always be at the same place and easily reachable. IMHO this best place is at the very top of the settings, but #92 has a different idea (at the bottom – but then you always have to scroll down to the bottom …)

This PR implements this with the check box(es) always at the top. If the check box should be at the bottom, the method `setting.settings.Settings.getNames()` should be changed from
```python
    def getNames(self):
        """Return list of names."""
        return self.hideboxnames + self.setnames
```
to
```python
    def getNames(self):
        """Return list of names."""
        return self.setnames + self.hideboxnames
```
This could be even made a configuration option? But then I am not sure, if the reversal of
```python
   def saveText(self, saveall, rootname = None):
```
would still work, if the file is loaded with the checkboxes set to a different position …