### PR TITLE
Enabling copy and paste as image

### DIFF
--- a/veusz/document/mime.py
+++ b/veusz/document/mime.py
@@ -32,7 +32,7 @@ widgetmime = 'text/x-vnd.veusz-widget-3'
 # dataset mime
 datamime = 'text/x-vnd.veusz-data-1'
 
-# svg mime
+# svg mime (convertable to `svgfile` widget)
 svgmime = 'image/svg+xml'
 
 def generateWidgetsMime(widgets):
@@ -103,12 +103,8 @@ def isClipboardDataMime():
 
 def getWidgetMime(mimedata):
     """Given mime data, return decoded python string."""
-    formats = mimedata.formats()
-    if widgetmime in formats:
+    if widgetmime in mimedata.formats():
         return mimedata.data(widgetmime).data().decode('utf-8')
-    elif svgmime in formats:
-        ba = mimedata.data(svgmime).data()
-        return convertImgtoWidgetMime(ba, svgmime)
     else:
         return None
 
@@ -118,9 +114,14 @@ def getClipboardWidgetMime():
     If mimedata is set, use this rather than clipboard directly
     """
     clipboard = qt.QApplication.clipboard()
-    clipboardwidgetmime = getWidgetMime(clipboard.mimeData())
-    if clipboardwidgetmime is not None:
-        return clipboardwidgetmime
+    mimedata = clipboard.mimeData()
+    formats = mimedata.formats()
+    widgetmime = getWidgetMime(mimedata)
+    if widgetmime is not None:
+        return widgetmime
+    elif svgmime in formats:
+        ba = mimedata.data(svgmime).data()
+        return convertImgtoWidgetMime(ba, svgmime)
     else:
         qimage = clipboard.image()
         if qimage.isNull():
@@ -130,7 +131,7 @@ def getClipboardWidgetMime():
             buffer = qt.QBuffer(ba)
             buffer.open(qt.QIODevice.WriteOnly)
             qimage.save(buffer, 'png')
-            return convertImgtoWidgetMime(ba, 'png')
+            return convertImgtoWidgetMime(ba, 'image/png')
 
 def getMimeWidgetTypes(data):
     """Get list of widget types in the mime data."""

--- a/veusz/widgets/shape.py
+++ b/veusz/widgets/shape.py
@@ -541,7 +541,6 @@ class SVGFile(BoxShape):
                         rect.width(), irect.height()*xr)
 
             # finally draw image
-            # painter.drawImage(rect, image, irect)
             image.render(painter, rect)
 
 document.thefactory.register(Ellipse)

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -1170,8 +1170,8 @@ class TreeEditDock(qt.QDockWidget):
     def slotWidgetCopyAsImage(self):
         """Copy current page to the clipboard as image files."""
         # general image extentions and their mime types exportable from document
-        exts = {'svg': ['image/svg+xml'], 
-                'png': ['image/png', 'PNG'], 
+        exts = {'svg': ['image/svg+xml'],
+                'png': ['image/png', 'PNG'],
                 'bmp': ['image/x-bmp'],
                 }
 
@@ -1197,7 +1197,7 @@ class TreeEditDock(qt.QDockWidget):
                         pass
 
                 # set QMimeData to clipboard
-                clipboard.setMimeData(data)          
+                clipboard.setMimeData(data)
                 tmpdir.cleanup()
 
             except:
@@ -1223,7 +1223,7 @@ class TreeEditDock(qt.QDockWidget):
 
         # export images to temporary files
         for ext in exts:
-            fname = tmpdir.name + '/tmp.{}'.format(ext)
+            fname = os.path.join(tmpdir.name, 'tmp.{}'.format(ext))
             export.add(fname, pages)
 
         # copy images to clipboard after finishing export

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -1187,7 +1187,7 @@ class TreeEditDock(qt.QDockWidget):
                 # set images to QMimeData
                 for ext, mimes in exts.items():
                     try:
-                        fname = tmpdir.name + '/tmp.{}'.format(ext)
+                        fname = os.path.join(tmpdir.name, 'tmp.{}'.format(ext))
                         with open(fname, 'rb') as fo:
                             bs = fo.read()
                         for mime in mimes:

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -19,6 +19,9 @@
 """Window to edit the document using a tree, widget properties
 and formatting properties."""
 
+import os
+import tempfile
+
 from .. import qtall as qt
 
 from .. import widgets
@@ -812,7 +815,7 @@ class TreeEditDock(qt.QDockWidget):
 
         # actions on widget(s)
         for act in (
-                'edit.cut', 'edit.copy', 'edit.paste',
+                'edit.cut', 'edit.copy', 'edit.copy_as_image', 'edit.paste',
                 'edit.moveup', 'edit.movedown', 'edit.delete',
                 'edit.rename'
         ):
@@ -916,7 +919,7 @@ class TreeEditDock(qt.QDockWidget):
         isnotroot = not any([isinstance(w, widgets.Root)
                              for w in self.selwidgets])
 
-        for act in ('edit.cut', 'edit.copy', 'edit.delete',
+        for act in ('edit.cut', 'edit.copy', 'edit.copy_as_image', 'edit.delete',
                     'edit.moveup', 'edit.movedown', 'edit.rename'):
             self.vzactions[act].setEnabled(isnotroot)
 
@@ -979,6 +982,10 @@ class TreeEditDock(qt.QDockWidget):
                 self, _('Copy the selected widget'), _('&Copy'),
                 self.slotWidgetCopy,
                 icon='kde-edit-copy', key='Ctrl+C'),
+            'edit.copy_as_image': a(
+                self, _('Copy the current page as svg image'), _('&Copy as Image'),
+                self.slotWidgetCopyAsImage,
+                icon='kde-edit-copy', key='Ctrl+Alt+C'),
             'edit.paste': a(
                 self, _('Paste widget from the clipboard'), _('&Paste'),
                 self.slotWidgetPaste,
@@ -1078,6 +1085,7 @@ class TreeEditDock(qt.QDockWidget):
             ('edit', '', (
                 'edit.cut',
                 'edit.copy',
+                'edit.copy_as_image',
                 'edit.paste',
                 'edit.delete',
                 'edit.rename',
@@ -1101,7 +1109,7 @@ class TreeEditDock(qt.QDockWidget):
         utils.addToolbarActions(
             self.edittoolbar,  actions,
             (
-                'edit.cut', 'edit.copy', 'edit.paste',
+                'edit.cut', 'edit.copy', 'edit.copy_as_image', 'edit.paste',
                 'edit.moveup', 'edit.movedown',
                 'edit.delete', 'edit.rename',
             )
@@ -1158,6 +1166,70 @@ class TreeEditDock(qt.QDockWidget):
             mimedata = document.generateWidgetsMime(self.selwidgets)
             clipboard = qt.QApplication.clipboard()
             clipboard.setMimeData(mimedata)
+
+    def slotWidgetCopyAsImage(self):
+        """Copy current page to the clipboard as image files."""
+        # general image extentions and their mime types exportable from document
+        exts = {'svg': ['image/svg+xml'], 
+                'png': ['image/png', 'PNG'], 
+                'bmp': ['image/x-bmp'],
+                }
+
+        def checkDone(export, exts):
+            """Check whether exporting pages as images has finished."""
+            if not export.haveDone():
+                return
+            try:
+                export.finish()
+                clipboard = qt.QApplication.clipboard()
+                data = qt.QMimeData()
+
+                # set images to QMimeData
+                for ext, mimes in exts.items():
+                    try:
+                        fname = tmpdir.name + '/tmp.{}'.format(ext)
+                        with open(fname, 'rb') as fo:
+                            bs = fo.read()
+                        for mime in mimes:
+                            data.setData(mime, bs)
+                        os.remove(fname)
+                    except:
+                        pass
+
+                # set QMimeData to clipboard
+                clipboard.setMimeData(data)          
+                tmpdir.cleanup()
+
+            except:
+                qt.QMessageBox.critical(self, _("Error - Veusz"), _("Error while exporting images"))
+            self.checktimer.stop()
+
+        # read settings from settingdb
+        setdb = setting.settingdb
+        export = document.AsyncExport(
+            self.document,
+            bitmapdpi=setdb['export_DPI'],
+            pdfdpi=setdb['export_DPI_PDF'],
+            antialias=setdb['export_antialias'],
+            color=setdb['export_color'],
+            quality=setdb['export_quality'],
+            backcolor=setdb['export_background'],
+            svgtextastext=setdb['export_SVG_text_as_text'],
+            svgdpi=setdb['export_DPI_SVG'],
+        )
+
+        tmpdir = tempfile.TemporaryDirectory()
+        pages = [self.parentwin.plot.getPageNumber()]
+
+        # export images to temporary files
+        for ext in exts:
+            fname = tmpdir.name + '/tmp.{}'.format(ext)
+            export.add(fname, pages)
+
+        # copy images to clipboard after finishing export
+        self.checktimer = qt.QTimer(self)
+        self.checktimer.timeout.connect(lambda: checkDone(export, exts))
+        self.checktimer.start(20)
 
     def updatePasteButton(self):
         """Is the data on the clipboard a valid paste at the currently


### PR DESCRIPTION
# Abstract
This pull request is an answer to https://github.com/veusz/veusz/issues/395#issue-589261447
This update enables
- copying a plot page to the clipboard as images
- pasting an clipboard image on the plot page.

I think it would be useful when users want to frequently exchange images with other software.
![output5](https://user-images.githubusercontent.com/30950088/108617671-bd32c880-745b-11eb-8023-a1ef08f0b3d4.gif)

# Copy as image
## Behavior
- "Copy as Image" menu appears when a user right click on the tree edit window.
- "Ctrl + Alt + C" is assigned to the shortcut of this action.
- DPI and other parameters depend on the settings of usual "export".
- "Copy as Image" exports the selected page as 3 types of images, and copies them to clipboard as 4 types of mime data
    - "image/svg+xml" (.svg)
    - "image/png" (.png)
    - "PNG" (.png)
    - "image/x-bmp" (.bmp)
- I checked that either of the 4 mime type can be pasted to major software, as shown below.

|  | image/svg+xml | image/png | PNG | image/x-bmp |
----|----|----|----|----|
| Inkscape | ok | ok | ok | ok |
| GIMP (on Ubuntu) | NG | ok | ok | ok |
| GIMP (on Windows) | NG | NG | ok | ok |
| LibreOffice (on Ubuntu)  | NG | ok | NG | NG |
| LibreOffice (on Windows) | NG | NG | ok | NG |
| MS Office (-2016) | NG | NG | ok | NG |
| MS Office (2019-, 365) | ok | NG | ok | NG |

## Changed files
- veusz.windows.treeeditwindow.py

## Known concerns & points to be discussed
- The images are exported as overall page, even when only several widgets in the page are selected. 
- I implemented "Copy as Image" separately from "Copy". Integrating them into "Copy" (always copy widget and image simulataneously) might be simpler. 

# Paste
## Behavior
- If clipboard contains image mime types, "Paste" action (on the tree edit window) convert the data to veusz "imagefile" widget, and then paste it.
- The program searches mime types in the following priority order:
    - 'text/x-vnd.veusz-widget-3', 'image/svg+xml', 'image/png', 'PNG', 'image/x‑xpixmap', 'image/x-bmp', 'image/x‑xbm', 'image/x‑xbitmap', 'image/tiff',  'image/jpeg', 'JFIF', 'GIF'
- I checked that images from major software (as shown below) can be correctly pasted.
    - Inkscape (as svg)
    - GIMP (as raster)
    - LibreOffice (as raster)
    - MS Office 2016 (as raster)
    - MS Office 2019, 365 (as svg)
    - Print-screen (not works on Windows)
    - Firefox, Chrome (not works on Windows)

## Changed files
- veusz.document.mime.py

## Known concerns & points to be discussed
- Print-screen images or copied images from web-browsers cannot be pasted on MS WIndows.
  It is because Windows HBITMAP format is not supported so far. HBITMAP data are not accessible by PyQt qt.QApplication.clipboard().mimeData().