### PR TITLE
Use sipbuild API instead of invoking sip as a subprocess

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -14,7 +14,7 @@ Requirements:
 PyQt requires
  Qt5 >= 5.5      https://www.qt.io/developers/
                  latest version recommended
- SIP 4.x >= 4.15 https://www.riverbankcomputing.co.uk/software/sip/
+ SIP >= 5        https://www.riverbankcomputing.com/software/sip/
 
 Optional requirements:
  h5py            http://www.h5py.org/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ external sources such as Internet sockets or other programs.
   * [Python](https://www.python.org/) 3.x (3.3 or greater required)
   * [Qt](https://www.qt.io/) >= 5.5 (free edition)
   * [PyQt](http://www.riverbankcomputing.co.uk/software/pyqt/) >= 5.2  (Qt and SIP is required to be installed first)
-  * [SIP](http://www.riverbankcomputing.co.uk/software/sip/) >= 4.15
+  * [SIP](http://www.riverbankcomputing.co.uk/software/sip/) >= 5
   * [Numpy](http://numpy.scipy.org/) >= 1.7
 
 ## Optional requirements:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy >= 1.10
 PyQt5 >= 5.5.1
-sip >=4.17,<6.0
+sip >= 5
 astropy >= 2.0
 h5py >= 2.6.0


### PR DESCRIPTION
This adds support for the latest SIP versions (6.x) but removes support for SIP v4.

Background:

- SIP 5.0.0 was released on 2019-10-08.
- SIP 6.0.0 was released on 2021-01-04.
- SIP developer [wrote](https://www.riverbankcomputing.com/pipermail/pyqt/2020-September/043162.html) in September 2020:
  > SIP v4 has been deprecated for more than a year. *Nobody* should still be using it.
- In #433 I added support for SIP v5. The code used `sip5` legacy tool that was present in SIP v5 for compatibility with v4.
- In SIP v6, that tool is not present. So we have two ways: either use SIP's own buildsystem (`sip-build` command-line tool), or use the `sipbuild` API from Python. Here I went with the second approach.

To test this, try installing the latest versions of `sip`, `PyQt5` and `PyQt5.sip` from PyPI. On Debian, install `python3-sipbuild` from experimental (it may want to remove `sip5-tools`, if you need that package its new name is `sip-tools`).