### PR TITLE
Improvement of Bezier join

### DIFF
--- a/veusz/helpers/src/qtloops/beziers_qtwrap.cpp
+++ b/veusz/helpers/src/qtloops/beziers_qtwrap.cpp
@@ -49,3 +49,81 @@ QPolygonF bezier_fit_cubic_multi( const QPolygonF& data, double error,
     return QPolygonF();
 }
 
+QPolygonF bezier_fit_cubic_tight(const QPolygonF& data, double looseness)
+{
+ /**
+  * MS Excel-like cubic Bezier fitting formulated by Brian Murphy.
+  * (http://www.xlrotor.com/Smooth_curve_bezier_example_file.zip)
+  * 
+  * 4 bezier control points (ctrls[0]-ctrl[3]) are created for each line
+  * segment. Positions of ctrls are determined by 4 nearest data points
+  * (pt0-pt3) with following rules:
+  * ctrls[0]: same position as pt0.
+  * ctrls[1]: on a line through pt1 parallel to pt0-pt2,
+  *           at a distance from pt1 = f1 * |pt0-pt2|
+  * ctrls[2]: on a line through pt2 parallel to pt1-pt3,
+  *           at a distance from pt2 = f2 * |pt1-pt3|
+  * ctrls[3]: same position as pt3
+  * The magic numbers (f1 and f2) are determined by length ratio of the
+  * 3 line segments and "looseness" with some additional rules.
+  * looseness: artificial parameter to control "tension" of the Bezier
+  *            curve. Larger value gives more curved connection.
+  *            In MS Excell, this value is set as "0.5".
+  */
+  const int len = data.size();
+  if (len < 2) {
+    return QPolygonF();
+  }else if (len == 2) {
+    QPolygonF bezier_ctrls(4);
+    bezier_ctrls << data[0] << data[0] << data[1] << data[1];
+    return bezier_ctrls;
+  }else{
+    QPolygonF bezier_ctrls(4 * (len - 1));
+    for (int i = 1; i < len; i++) {
+      QPolygonF ctrls(4);
+      QPointF pt0;
+      QPointF pt1 = data[i-1];
+      QPointF pt2 = data[i];
+      QPointF pt3;
+      ctrls[0] = pt1;
+      ctrls[3] = pt2;
+      double f1;
+      double f2;
+      if (i == 1) {
+        pt0 = data[i-1];
+        pt3 = data[i+1];
+        f1 = looseness / 1.5;
+        f2 = looseness / 3.0;
+      }else if  (i == len - 1) {
+        pt0 = data[i-2];
+        pt3 = data[i];
+        f1 = looseness / 3.0;
+        f2 = looseness / 1.5;
+      }else{
+        pt0 = data[i-2];
+        pt3 = data[i+1];
+        f1 = looseness / 3.0;
+        f2 = looseness / 3.0;
+      }
+      double d02 = QLineF(pt0, pt2).length();
+      double d12 = QLineF(pt1, pt2).length();
+      double d13 = QLineF(pt1, pt3).length();
+      bool b1 = d02 < d12 * 3.0;
+      bool b2 = d13 < d12 * 3.0;
+      if (!(b1 && b2)) {
+        f1 = d12 / d02 / 2.0;
+        f2 = d12 / d13 / 2.0;
+        if (b1) {
+          f1 = f2;
+        }
+        if (b2) {
+          f2 = f1;
+        }
+      }
+      ctrls[1] = pt1 + (pt2 - pt0) * f1;
+      ctrls[2] = pt2 + (pt1 - pt3) * f2;
+      bezier_ctrls += ctrls;
+    }
+    return bezier_ctrls;
+  }
+}

--- a/veusz/helpers/src/qtloops/beziers_qtwrap.h
+++ b/veusz/helpers/src/qtloops/beziers_qtwrap.h
@@ -22,9 +22,11 @@
 #define BEZIERS_QTWRAP_H
 
 #include <QPolygonF>
+#include <QLineF>
 
 QPolygonF bezier_fit_cubic_single(const QPolygonF& data, double error);
 QPolygonF bezier_fit_cubic_multi(const QPolygonF& data, double error,
 				 unsigned max_beziers);
+QPolygonF bezier_fit_cubic_tight(const QPolygonF& data, double looseness);
 
 #endif

--- a/veusz/helpers/src/qtloops/qtloops.sip
+++ b/veusz/helpers/src/qtloops/qtloops.sip
@@ -277,6 +277,8 @@ QPolygonF bezier_fit_cubic_single(const QPolygonF& data, double error);
 QPolygonF bezier_fit_cubic_multi(const QPolygonF& data, double error,
 				 unsigned max_beziers);
 
+QPolygonF bezier_fit_cubic_tight(const QPolygonF& data, double looseness);
+
 SIP_PYOBJECT binData(SIP_PYOBJECT data, int binning, bool average);
 %MethodCode
    try

--- a/veusz/setting/collections.py
+++ b/veusz/setting/collections.py
@@ -103,17 +103,17 @@ class XYPlotLine(Line):
             descr=_('Plot 90 degree steps instead of a line'),
             usertext=_('Steps')), 0 )
         self.add( setting.Choice(
-            'jointStyle',
+            'interpType',
             [
                 'linear', 'loose-Bezier', 'tight-Bezier',
             ],
             'linear',
             descr=_('Line style (linear/curved) to connect points'),
-            usertext=_('Joint style')), 1 )
-        # translate bezierJoin to jointStyle
+            usertext=_('Interpolation')), 1 )
+        # translate bezierJoin to interpType
         self.add( setting.SettingBackwardCompat(
             'bezierJoin',
-            'jointStyle',
+            'interpType',
             False,
             translatefn=lambda x: {
                 True: 'loose-Bezier',

--- a/veusz/setting/collections.py
+++ b/veusz/setting/collections.py
@@ -102,10 +102,25 @@ class XYPlotLine(Line):
             'off',
             descr=_('Plot 90 degree steps instead of a line'),
             usertext=_('Steps')), 0 )
-        self.add( setting.Bool(
-            'bezierJoin', False,
-            descr=_('Connect points with a cubic Bezier curve'),
-            usertext=_('Bezier join')), 1 )
+        self.add( setting.Choice(
+            'jointStyle',
+            [
+                'linear', 'loose-Bezier', 'tight-Bezier',
+            ],
+            'linear',
+            descr=_('Line style (linear/curved) to connect points'),
+            usertext=_('Joint style')), 1 )
+        # translate bezierJoin to jointStyle
+        self.add( setting.SettingBackwardCompat(
+            'bezierJoin',
+            'jointStyle',
+            False,
+            translatefn=lambda x: {
+                True: 'loose-Bezier',
+                False: 'linear'
+            }[x],
+            formatting=True,
+        ) )
         self.get('color').newDefault( Reference('../color') )
 
 class MarkerLine(Line):

--- a/veusz/widgets/point.py
+++ b/veusz/widgets/point.py
@@ -943,11 +943,11 @@ class PointPlotter(GenericPlotter):
             #print "Painting plot line"
             # plot data line (and/or filling above or below)
             if not s.PlotLine.hide or not s.FillAbove.hide or not s.FillBelow.hide:
-                jointstyle = s.PlotLine.jointStyle
-                if jointstyle != "linear":
+                interpolation_type = s.PlotLine.interpType
+                if interpolation_type != "linear":
                     self._drawBezierLine(
                         painter, xplotter, yplotter, posn,
-                        xvals, yvals, cliprect, jointstyle )
+                        xvals, yvals, cliprect, interpolation_type )
                 else:
                     self._drawPlotLine(
                         painter, xplotter, yplotter, posn,


### PR DESCRIPTION
## Issue
- Issue #547
- `PlotLine/bezierJoin` sometimes gives too loose curves.

## Proposed improvements
<img src="https://user-images.githubusercontent.com/30950088/131205556-aff066d6-0597-4dee-8b31-efc1759dc178.png" width="60%">

- Existing Bezier-fit was renamed to "loose-Bezier", and "tight-Bezier" was newly added.
- Core function `bezier_fit_cubic_tight` in beziers_qtwrap.cpp was added.
  - The algorithm is based on an Excel-like cubic Bezier fitting formulated by Brian Murphy (http://www.xlrotor.com/Smooth_curve_bezier_example_file.zip). 
    - 4 bezier control points (ctrls[0]-ctrl[3]) are created for each line segment. Positions of ctrls are determined by 4 nearest data points (pt0-pt3) with following rules:
      1. ctrls[0]: same position as pt0.
      2. ctrls[1]: on a line through pt1 parallel to pt0-pt2, at a distance from pt1 = f1 * |pt0-pt2|
      3. ctrls[2]: on a line through pt2 parallel to pt1-pt3, at a distance from pt2 = f2 * |pt1-pt3|
      4. ctrls[3]: same position as pt3
      5. The magic numbers (f1 and f2) are determined by length ratio of the 3 line segments and parameter "looseness" with some additional rules.

## API changes
- Replace `PlotLine/bezierJoin`(Bool) by `PlotLine/interpType`(linear / loose-Bezier / tight-Bezier)
- Parameter `bezierJoin=False` is interpreted as `interpType=linear`
- Parameter `bezierJoin=True` is interpreted as `interpType=loose-Bezier`

## Discussion
- There might be a better name for the new parameter `interpType`.
  - e.g. `interpMethod`, `interpolation`, `jointType`, `jointCurve`, etc...