### PR TITLE
Fitting limits exdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Documents/manual/
 
 .idea/
 veusz.egg-info/
+
+*__pycache__*
+

--- a/veusz/dataimport/simpleread.py
+++ b/veusz/dataimport/simpleread.py
@@ -58,7 +58,7 @@ descrtokens_split_re = re.compile(r'''
  `[^`]*`       |  # quoted name
  [ ,]          |  # comma or space
  \([a-z]+?\)   |  # data type
- \+- | \+ | - | = |  # error bars  ##J = denotes flags
+ \+- | \+ | - | = |  # error bars = denotes flags
  \[.*?\]          # indices
 )
 ''', re.VERBOSE)
@@ -105,7 +105,7 @@ def interpretDescriptor(descr):
             continue
 
         # match error bars
-        if token in ('+', '-', '+-','='):  ##J
+        if token in ('+', '-', '+-','='):  
             columns.append(token)
             continue
 
@@ -306,20 +306,20 @@ class DescriptorPart:
             # does the dataset exist?
             if name+'\0D' in thedatasets:
                 vals = thedatasets[name+'\0D']
-                pos = neg = sym = flags = None  ##J
+                pos = neg = sym = flags = None  
 
                 # retrieve the data for this dataset
                 if name+'\0+' in thedatasets: pos = thedatasets[name+'\0+']
                 if name+'\0-' in thedatasets: neg = thedatasets[name+'\0-']
                 if name+'\0+-' in thedatasets: sym = thedatasets[name+'\0+-']
-                if name+'\0=' in thedatasets: flags = thedatasets[name+'\0='] ##J
+                if name+'\0=' in thedatasets: flags = thedatasets[name+'\0='] 
 
                 # make sure components are the same length
                 minlength = 99999999999999
-                for ds in vals, pos, neg, sym, flags: ##J added flags
+                for ds in vals, pos, neg, sym, flags:
                     if ds is not None and len(ds) < minlength:
                         minlength = len(ds)
-                for ds in vals, pos, neg, sym, flags:  ##J added flags
+                for ds in vals, pos, neg, sym, flags:
                     if ds is not None and len(ds) != minlength:
                         del ds[minlength:]
 
@@ -329,12 +329,12 @@ class DescriptorPart:
                     if sym is not None: sym = sym[-tail:]
                     if pos is not None: pos = pos[-tail:]
                     if neg is not None: neg = neg[-tail:]
-                    if flags is not None: flags = flags[-tail:]  ##J
+                    if flags is not None: flags = flags[-tail:]  
 
                 # create the dataset
                 if self.datatype == 'float':
                     ds = datasets.Dataset( data = vals, serr = sym,
-                                           nerr = neg, perr = pos, flags=flags, ##J
+                                           nerr = neg, perr = pos, flags=flags, 
                                            linked = linkedfile )
                 elif self.datatype == 'date':
                     ds = datasets.DatasetDateTime( data=vals,

--- a/veusz/datasets/date.py
+++ b/veusz/datasets/date.py
@@ -77,7 +77,7 @@ class DatasetDateTime(DatasetDateTimeBase):
         DatasetDateTimeBase.__init__(self, linked=linked)
 
         self.data = convertNumpy(data)
-        self.perr = self.nerr = self.serr = None
+        self.perr = self.nerr = self.serr = self.flags = None 
 
     def saveDataDumpToText(self, fileobj, name):
         '''Save data to file.

--- a/veusz/datasets/expression.py
+++ b/veusz/datasets/expression.py
@@ -33,7 +33,7 @@ from .. import utils
 dataexpr_split_re = re.compile(r'(`.*?`|[\.+\-*/\(\)\[\],<>=!|%^~& ])')
 # identify whether string is a quoted identifier
 dataexpr_quote_re = re.compile(r'^`.*`$')
-# data values, errors and new 'flags' field for marking data e.g. as problematic ##J
+# data values, errors and new 'flags' field for marking data e.g. as problematic 
 dataexpr_columns = {'data':True, 'serr':True, 'perr':True, 'nerr':True, 'flags':True}
 
 def substituteDatasets(datasets, expression, thispart):
@@ -241,7 +241,7 @@ class DatasetExpression(Dataset1DBase):
 
     dstype = _('Expression')
 
-    def __init__(self, data=None, serr=None, nerr=None, perr=None, flags=None, ##J
+    def __init__(self, data=None, serr=None, nerr=None, perr=None, flags=None, 
                  parametric=None):
         """Initialise the dataset with the expressions given.
 
@@ -256,7 +256,7 @@ class DatasetExpression(Dataset1DBase):
         self.expr['serr'] = serr
         self.expr['nerr'] = nerr
         self.expr['perr'] = perr
-        self.expr['flags'] = flags ##J
+        self.expr['flags'] = flags 
         self.parametric = parametric
 
         self.docchangeset = -1
@@ -370,7 +370,7 @@ class DatasetExpression(Dataset1DBase):
     serr = property(lambda self: self._propValues('serr'))
     perr = property(lambda self: self._propValues('perr'))
     nerr = property(lambda self: self._propValues('nerr'))
-    flags = property(lambda self: self._propValues('flags')) ##J
+    flags = property(lambda self: self._propValues('flags')) 
     
 
     def saveDataRelationToText(self, fileobj, name):
@@ -385,7 +385,7 @@ class DatasetExpression(Dataset1DBase):
         if self.expr['perr']:
             parts.append('poserr=%s' % repr(self.expr['perr']))
         if self.expr['flags']:
-            parts.append('flags=%s' % repr(self.expr['flags'])) ##J
+            parts.append('flags=%s' % repr(self.expr['flags'])) 
         if self.parametric is not None:
             parts.append('parametric=%s' % repr(self.parametric))
 

--- a/veusz/datasets/expression.py
+++ b/veusz/datasets/expression.py
@@ -33,7 +33,8 @@ from .. import utils
 dataexpr_split_re = re.compile(r'(`.*?`|[\.+\-*/\(\)\[\],<>=!|%^~& ])')
 # identify whether string is a quoted identifier
 dataexpr_quote_re = re.compile(r'^`.*`$')
-dataexpr_columns = {'data':True, 'serr':True, 'perr':True, 'nerr':True}
+# data values, errors and new 'flags' field for marking data e.g. as problematic ##J
+dataexpr_columns = {'data':True, 'serr':True, 'perr':True, 'nerr':True, 'flags':True}
 
 def substituteDatasets(datasets, expression, thispart):
     """Substitute the names of datasets with calls to a function which will
@@ -240,7 +241,7 @@ class DatasetExpression(Dataset1DBase):
 
     dstype = _('Expression')
 
-    def __init__(self, data=None, serr=None, nerr=None, perr=None,
+    def __init__(self, data=None, serr=None, nerr=None, perr=None, flags=None, ##J
                  parametric=None):
         """Initialise the dataset with the expressions given.
 
@@ -255,6 +256,7 @@ class DatasetExpression(Dataset1DBase):
         self.expr['serr'] = serr
         self.expr['nerr'] = nerr
         self.expr['perr'] = perr
+        self.expr['flags'] = flags ##J
         self.parametric = parametric
 
         self.docchangeset = -1
@@ -368,6 +370,8 @@ class DatasetExpression(Dataset1DBase):
     serr = property(lambda self: self._propValues('serr'))
     perr = property(lambda self: self._propValues('perr'))
     nerr = property(lambda self: self._propValues('nerr'))
+    flags = property(lambda self: self._propValues('flags')) ##J
+    
 
     def saveDataRelationToText(self, fileobj, name):
         '''Save data to file.
@@ -380,6 +384,8 @@ class DatasetExpression(Dataset1DBase):
             parts.append('negerr=%s' % repr(self.expr['nerr']))
         if self.expr['perr']:
             parts.append('poserr=%s' % repr(self.expr['perr']))
+        if self.expr['flags']:
+            parts.append('flags=%s' % repr(self.expr['flags'])) ##J
         if self.parametric is not None:
             parts.append('parametric=%s' % repr(self.parametric))
 

--- a/veusz/datasets/histo.py
+++ b/veusz/datasets/histo.py
@@ -245,6 +245,7 @@ class DatasetHistoBins(Dataset1DBase):
     nerr = property(lambda self: self.getData()[1])
     perr = property(lambda self: self.getData()[2])
     serr = None
+    flags = None 
 
 class DatasetHistoValues(Dataset1DBase):
     """A dataset for getting the height of the bins in a histogram."""
@@ -284,3 +285,4 @@ class DatasetHistoValues(Dataset1DBase):
     nerr = property(lambda self: self.getData()[1])
     perr = property(lambda self: self.getData()[2])
     serr = None
+    flags = None 

--- a/veusz/document/operations.py
+++ b/veusz/document/operations.py
@@ -616,16 +616,16 @@ class OperationDatasetCreateRange(OperationDatasetCreate):
         serr = self.parts.get('serr', None)
         perr = self.parts.get('perr', None)
         nerr = self.parts.get('nerr', None)
-        flags = self.parts.get('flags', None) ##J
+        flags = self.parts.get('flags', None) 
 
         ds = datasets.DatasetRange(
             self.numsteps, data, serr=serr,
-            perr=perr, nerr=nerr, flags=flags) ##J
+            perr=perr, nerr=nerr, flags=flags) 
         if not self.linked:
             # copy these values if we don't want to link
             ds = datasets.Dataset(
                 data=ds.data, serr=ds.serr,
-                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) ##J
+                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) 
 
         document.setData(self.datasetname, ds)
         return ds
@@ -666,7 +666,7 @@ class OperationDatasetCreateParameteric(OperationDatasetCreate):
             # copy these values if we don't want to link
             ds = datasets.Dataset(
                 data=ds.data, serr=ds.serr,
-                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) ##J
+                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) 
 
         document.setData(self.datasetname, ds)
         return ds
@@ -716,7 +716,7 @@ class OperationDatasetCreateExpression(OperationDatasetCreate):
             # copy these values if we don't want to link
             ds = datasets.Dataset(
                 data=ds.data, serr=ds.serr,
-                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) ##J
+                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) 
 
         document.setData(self.datasetname, ds)
         return ds

--- a/veusz/document/operations.py
+++ b/veusz/document/operations.py
@@ -616,15 +616,16 @@ class OperationDatasetCreateRange(OperationDatasetCreate):
         serr = self.parts.get('serr', None)
         perr = self.parts.get('perr', None)
         nerr = self.parts.get('nerr', None)
+        flags = self.parts.get('flags', None) ##J
 
         ds = datasets.DatasetRange(
             self.numsteps, data, serr=serr,
-            perr=perr, nerr=nerr)
+            perr=perr, nerr=nerr, flags=flags) ##J
         if not self.linked:
             # copy these values if we don't want to link
             ds = datasets.Dataset(
                 data=ds.data, serr=ds.serr,
-                perr=ds.perr, nerr=ds.nerr)
+                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) ##J
 
         document.setData(self.datasetname, ds)
         return ds
@@ -665,7 +666,7 @@ class OperationDatasetCreateParameteric(OperationDatasetCreate):
             # copy these values if we don't want to link
             ds = datasets.Dataset(
                 data=ds.data, serr=ds.serr,
-                perr=ds.perr, nerr=ds.nerr)
+                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) ##J
 
         document.setData(self.datasetname, ds)
         return ds
@@ -715,7 +716,7 @@ class OperationDatasetCreateExpression(OperationDatasetCreate):
             # copy these values if we don't want to link
             ds = datasets.Dataset(
                 data=ds.data, serr=ds.serr,
-                perr=ds.perr, nerr=ds.nerr)
+                perr=ds.perr, nerr=ds.nerr, flags=ds.flags) ##J
 
         document.setData(self.datasetname, ds)
         return ds

--- a/veusz/widgets/boxplot.py
+++ b/veusz/widgets/boxplot.py
@@ -300,9 +300,10 @@ class BoxPlot(GenericPlotter):
                 values = s.get('values').getData(doc)
                 if values:
                     for v in values:
-                        if len(v.data) > 0:
-                            axrange[0] = min(axrange[0], N.nanmin(v.data))
-                            axrange[1] = max(axrange[1], N.nanmax(v.data))
+                        validdata = v.validatedData()
+                        if len(validdata) > 0:
+                            axrange[0] = min(axrange[0], N.nanmin(validdata))
+                            axrange[1] = max(axrange[1], N.nanmax(validdata))
             else:
                 # update from manual entries
                 drange = self.rangeManual()
@@ -459,7 +460,7 @@ class BoxPlot(GenericPlotter):
             # calculated boxes
             for vals, plotpos in zip(values, plotposns):
                 stats = _Stats()
-                stats.calculate(vals.data, s.whiskermode)
+                stats.calculate(vals.validatedData(), s.whiskermode)
                 self.plotBox(
                     painter, axes, plotpos, widgetposn, width,
                     clip, stats)

--- a/veusz/widgets/fit.py
+++ b/veusz/widgets/fit.py
@@ -291,6 +291,7 @@ class Fit(FunctionPlotter):
             else:
                 print("Warning: No errors on y values. Assuming 5% errors.")
                 yserr = N.abs(yvals*0.05)
+                yserr[yserr < 1e-8] = 1e-8
 
         # if the fitRange parameter is on, we chop out data outside the
         # range of the axis

--- a/veusz/widgets/histo.py
+++ b/veusz/widgets/histo.py
@@ -395,7 +395,10 @@ class Histo(GenericPlotter):
         ds = dsetn.getData(self.document)
         if ds is None or dsetn.isEmpty():
             return
-        data = ds.data
+        if ds.flags is not None:
+          data = ds.data[(N.int16(ds.flags) & N.int16(2))==0]
+        else:
+          data = ds.data
         if len(data) == 0:
             return
 

--- a/veusz/widgets/histo.py
+++ b/veusz/widgets/histo.py
@@ -395,10 +395,7 @@ class Histo(GenericPlotter):
         ds = dsetn.getData(self.document)
         if ds is None or dsetn.isEmpty():
             return
-        if ds.flags is not None:
-          data = ds.data[(N.int16(ds.flags) & N.int16(2))==0]
-        else:
-          data = ds.data
+        data = ds.validatedData()
         if len(data) == 0:
             return
 


### PR DESCRIPTION
## Issue

Sometimes it is necessary to exclude spurious datapoint(s) - for example as might result from an instrument malfunction - from a procedure (e.g curve fitting, histogram calculation) or graphical representation. To maintain an accurate record of the experiment good practice is to preserve the dataset rather than deleting the datapoint. Software such as Graphpad Prism has a functionality in which datapoints can be selectively excluded from processing/visualisation while keeping them with the rest of the data.

## Proposed improvements

One possible approach could be to add a 'flag' field to 1D datasets in Veusz allowing datapoints to be selectively omitted from histogram, boxplot and scatterplot representations and the curve fitting algorithm.

This appears as a column in the `Dataset editor`. By default Veusz populates a newly edited column with zeroes. In the suggested code, a value of 
- 1 = 'exclude from fitting'
- 2 = 'exclude from representation'
- 3 = 'exclude from fitting and representation'

![Scatter plot with curve fitting including a spurious datapoint](https://user-images.githubusercontent.com/63245137/131416735-661cc828-bf77-45ce-b113-827219aec790.png)
A spurious datapoint results in poor fitting of the remaining data

![Fitting performed with the datapoint specifically excluded without deleting](https://user-images.githubusercontent.com/63245137/131416915-738d7f39-e814-4886-b2b3-dc58c8714061.png)
Exclusion of the datapoint from the fitting algorithm results in a better fit without deletion of the data

![Datapoint not plotted](https://user-images.githubusercontent.com/63245137/131417043-b27d1171-6a60-4a09-9a32-b8e65e4e4777.png)
The datapoint remains part of the dataset but is not shown on the plot

![Boxplot with outlier](https://user-images.githubusercontent.com/63245137/131417429-5f015b8f-d2b1-4def-919e-3a7defa8c91b.png)
Boxplot of data with an outlier

![Boxplot with outlier excluded](https://user-images.githubusercontent.com/63245137/131417529-33952bfb-0f04-45e2-afa6-c1899d04927e.png)
Boxplot of data with the outlier excluded but not deleted

![Histogram including outlier](https://user-images.githubusercontent.com/63245137/131417705-c1e597fa-e0f8-4642-a42f-e97262ebc9e1.png)
Histogram including outlier

![Histogram excluding outlier](https://user-images.githubusercontent.com/63245137/131417747-ba76b4b5-c114-4d58-8f5e-a327b2a3e0f3.png)
Histogram excluding outlier

## Possible code changes

To implement this functionality mostly small changes have been made, e.g for creating or copying a `flags` object alongside existing error objects, with the most substantive additions in `oned.py`.
- A `flags` object has been added to the `Dataset1DBase` class. `Dataset`, `DatasetRange`, `DatasetHistoBins`, `DatasetHistoValues` and `DatasetDateTime` classes that inherit from it therefore also now define a `flags` object.
- Methods `flagExcludeUnset` (affecting display) and `flagDontProcessUnset` (affecting fitting) have been implemented. Existing indexing of valid data is through boolean arrays (chiefly from numpy.isfinite), so these methods return arrays where elements to be used/displayed are returned as `True` and those to be exluded/hidden as `False`.
- The existing `invalidDataPoints` method returned a boolean array from the inverse of a series of numpy.isfininite operations. This has been split into `validDataPoints` and `invalidDataPoints` to avoid an extra NOT operation in functions that require a list of _valid_ datapoints. These now take into account the output from `flagExcludeUnset`
- New method `validatedData` returns data values deemed valid by `validDataPoints`, i.e those with values/errors that satisfy both `isfinite` and `flagExcludeUnset` conditions. The histogram and boxplot widgets now use the output from this function in their calculations.
- Data indexing has been introduced in `getPointRanges`, `updateRangeAuto` and `rangeVisit` to ensure only points deemed valid by `validDataPoints` are used for the calculations.
- The `saveDataDumpToText` and `saveDataDumpToHDF5` methods denote flags in their text output with a '=' character
- The `DatasetExpression` class now defines, sets and prints a `flags` object
- `simpleread.py` now reads flag values (denoted by '=') alongside error values through an addition to the regex and `setOutput` method
- The classes `OperationDatasetCreateRange`, `OperationDatasetCreateParameteric` and `OperationDatasetCreateExpression` transfer the flags array alongside arrays of errors
- The `actionFit` method now not only requires `isfinite` to return true for a datapoint but for `flagDontProcessUnset` to return true both for the corresponding X and Y values

## Observations

I wanted to suggest this functionality to the developers but thought a demonstration of how it could be incorporated, as presented here, would be best.

Initially instead of making these additions to the code I did consider an approach where defining a datapoint's `serr` property as `nan` would exclude it from the fitting algorithm under the existing code.  However currently this then causes the dataset editor to automatically populate the serr values of other datapoints with '0' - making an explicit error definition for each point necessary. The effect of a `nan` error value is also currently treated inconsistently between different widgets (eg comparing fitting, histogram and boxplot). Increased use of `invalidDataPoints` (and `validDataPoints`) methods should also increase consistency as to what data is considered "valid". 

I hope this is of some interest!
