### PR TITLE
Fix +, -, .. button appearance issue on macOS

### DIFF
--- a/veusz/setting/controls.py
+++ b/veusz/setting/controls.py
@@ -52,6 +52,27 @@ class DotDotButton(qt.QPushButton):
         if tooltip:
             self.setToolTip(tooltip)
         self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
+        self.setStyleSheet('QPushButton { padding: 0; margin: 16; }')
+
+class AddButton(qt.QPushButton):
+    """A button to add item."""
+    def __init__(self):
+        qt.QPushButton.__init__(
+            self, "+", flat=True, 
+            maximumWidth=24, maximumHeight=24)
+        self.setToolTip('Add another item')
+        self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
+        self.setStyleSheet('QPushButton { padding: 0; margin: 24; }')
+
+class SubButton(qt.QPushButton):
+    """A button to subtract item."""
+    def __init__(self):
+        qt.QPushButton.__init__(
+            self, "-", flat=True, 
+            maximumWidth=24, maximumHeight=24)
+        self.setToolTip('Remove item')
+        self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
+        self.setStyleSheet('QPushButton { padding: 0; margin: 24; }')
 
 class Edit(qt.QLineEdit):
     """Main control for editing settings which are text."""
@@ -1572,14 +1593,8 @@ class MultiSettingWidget(qt.QWidget):
         row = len(self.controls)
         cntrl = self.makeControl(row)
         cntrl.installEventFilter(self)
-        addbutton = qt.QPushButton('+')
-        addbutton.setFixedWidth(24)
-        addbutton.setFlat(True)
-        addbutton.setToolTip('Add another item')
-        subbutton = qt.QPushButton('-')
-        subbutton.setToolTip('Remove item')
-        subbutton.setFixedWidth(24)
-        subbutton.setFlat(True)
+        addbutton = AddButton()
+        subbutton = SubButton()
 
         self.controls.append((cntrl, addbutton, subbutton))
 
@@ -2016,3 +2031,4 @@ class AxisBound(Choice):
 
         if self.currentText().lower() != 'auto':
             self.setEditText( self.setting.toUIText() )
+

--- a/veusz/setting/controls.py
+++ b/veusz/setting/controls.py
@@ -57,21 +57,17 @@ class DotDotButton(qt.QPushButton):
 class AddButton(qt.QPushButton):
     """A button to add item."""
     def __init__(self):
-        qt.QPushButton.__init__(
-            self, "+", flat=True, 
-            maximumWidth=24, maximumHeight=24)
+        qt.QPushButton.__init__(self, "+", flat=True)
+        self.setFixedWidth(24)
         self.setToolTip('Add another item')
-        self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
         self.setStyleSheet('QPushButton { padding: 0; }')
 
 class SubButton(qt.QPushButton):
     """A button to subtract item."""
     def __init__(self):
-        qt.QPushButton.__init__(
-            self, "-", flat=True, 
-            maximumWidth=24, maximumHeight=24)
+        qt.QPushButton.__init__(self, "-", flat=True)
+        self.setFixedWidth(24)
         self.setToolTip('Remove item')
-        self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
         self.setStyleSheet('QPushButton { padding: 0; }')
 
 class Edit(qt.QLineEdit):

--- a/veusz/setting/controls.py
+++ b/veusz/setting/controls.py
@@ -52,7 +52,7 @@ class DotDotButton(qt.QPushButton):
         if tooltip:
             self.setToolTip(tooltip)
         self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
-        self.setStyleSheet('QPushButton { padding: 0; margin: 16; }')
+        self.setStyleSheet('QPushButton { padding: 0; }')
 
 class AddButton(qt.QPushButton):
     """A button to add item."""
@@ -62,7 +62,7 @@ class AddButton(qt.QPushButton):
             maximumWidth=24, maximumHeight=24)
         self.setToolTip('Add another item')
         self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
-        self.setStyleSheet('QPushButton { padding: 0; margin: 24; }')
+        self.setStyleSheet('QPushButton { padding: 0; }')
 
 class SubButton(qt.QPushButton):
     """A button to subtract item."""
@@ -72,7 +72,7 @@ class SubButton(qt.QPushButton):
             maximumWidth=24, maximumHeight=24)
         self.setToolTip('Remove item')
         self.setSizePolicy(qt.QSizePolicy.Maximum, qt.QSizePolicy.Maximum)
-        self.setStyleSheet('QPushButton { padding: 0; margin: 24; }')
+        self.setStyleSheet('QPushButton { padding: 0; }')
 
 class Edit(qt.QLineEdit):
     """Main control for editing settings which are text."""


### PR DESCRIPTION
## About
- Set `+` `-` `..` buttons padding to 0 to  make them visible on recent macOS
- Related issues: 
  - #570
  - #602

## How changed
### Before modification
- on macOS 12
  <img src="https://user-images.githubusercontent.com/30950088/187017587-2d8bdd31-bb5a-4d8f-ae69-2143252c309b.png" width="480">

### After modification
- on macOS 12
  <img src="https://user-images.githubusercontent.com/30950088/187021220-7e130a6e-4d97-4e5a-ad75-70c0b73add7a.png" width="480">

- on MS Windows 10
  <img src="https://user-images.githubusercontent.com/30950088/187020485-51511aa5-89be-4957-b0c7-6e8fd0c37431.png" width="480">

- on Ubuntu 22
  <img src="https://user-images.githubusercontent.com/30950088/187020088-54cad3cd-e330-4dc4-a8f9-f032e0e2fe5c.png" width="480">  

## Note
- `setAttribute(qt.Qt.WA_LayoutUsesWidgetRect)` was not effective.
- Remained issue: Clickable area is too small on macOS.
  ![1](https://user-images.githubusercontent.com/30950088/187020027-f8a35c78-67d6-417c-b9e6-7c0d9590cbae.png)
  By mofifying `margin` value and/or `QSizePolicy`, I have managed to find the condition to solve this clickable area issue on macOS. But these modifications make appearances on Windows and/or Linux incorrect. I have not yet found a setting to make appearance correct on the all three so far.