### PR TITLE
Duplicate widgets

### DIFF
--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -1259,12 +1259,20 @@ class TreeEditDock(qt.QDockWidget):
                 w = c
         self.selectWidget(w)
 
-    def slotWidgetPaste(self):
+    def slotWidgetPaste(self, append_name=None):
         """Paste something from the clipboard"""
 
         data = document.getClipboardWidgetMime()
         if data:
-            op = document.OperationWidgetPaste(self.selwidgets[0], data)
+            new_names = None
+
+            # update names, if requested to do so (used for duplication)
+            if append_name is not None:
+              new_names = [w.name + append_name for w in self.selwidgets]
+            op = document.OperationWidgetPaste(
+              self.selwidgets[0], data, -1, new_names
+            )
+
             widgets = self.document.applyOperation(op)
             if widgets:
                 self.selectWidget(widgets[0])
@@ -1273,7 +1281,7 @@ class TreeEditDock(qt.QDockWidget):
         """Duplicate selected widget"""
 
         self.slotWidgetCopy()
-        self.slotWidgetPaste()
+        self.slotWidgetPaste(append_name=" - copy")
 
     def slotWidgetDelete(self):
         """Delete the widget selected."""

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -816,7 +816,7 @@ class TreeEditDock(qt.QDockWidget):
         # actions on widget(s)
         for act in (
                 'edit.cut', 'edit.copy', 'edit.copy_as_image', 'edit.paste',
-                'edit.moveup', 'edit.movedown', 'edit.delete',
+                'edit.duplicate', 'edit.moveup', 'edit.movedown', 'edit.delete',
                 'edit.rename'
         ):
             m.addAction(self.vzactions[act])
@@ -990,6 +990,10 @@ class TreeEditDock(qt.QDockWidget):
                 self, _('Paste widget from the clipboard'), _('&Paste'),
                 self.slotWidgetPaste,
                 icon='kde-edit-paste', key='Ctrl+V'),
+            'edit.duplicate': a(
+                self, _('Duplicate widget'), _('&Duplicate'),
+                self.slotWidgetDuplicate,
+                key='Ctrl+D'),
             'edit.moveup': a(
                 self, _('Move the selected widget up'), _('Move &up'),
                 lambda: self.slotWidgetMove(-1),
@@ -1087,6 +1091,7 @@ class TreeEditDock(qt.QDockWidget):
                 'edit.copy',
                 'edit.copy_as_image',
                 'edit.paste',
+                'edit.duplicate',
                 'edit.delete',
                 'edit.rename',
                 'edit.moveup',
@@ -1263,6 +1268,12 @@ class TreeEditDock(qt.QDockWidget):
             widgets = self.document.applyOperation(op)
             if widgets:
                 self.selectWidget(widgets[0])
+
+    def slotWidgetDuplicate(self):
+        """Duplicate selected widget"""
+
+        self.slotWidgetCopy()
+        self.slotWidgetPaste()
 
     def slotWidgetDelete(self):
         """Delete the widget selected."""


### PR DESCRIPTION
I find it useful to have a context menu entry for quickly duplicating existing widgets.  The easiest way I found for implementing this was to do a combined copy+past operation.  I thought this is nice because it reuses existing code (with a small modification to support renaming).  But if the clipboard altering side-effect is undesirable, we could also work out a different solution.