### PR TITLE
change histgram2d() arg from 'normed' to 'density'

### DIFF
--- a/veusz/plugins/datasetplugin.py
+++ b/veusz/plugins/datasetplugin.py
@@ -1968,7 +1968,7 @@ class Histogram2D(DatasetPlugin):
         # compute counts in each bin
         histo, xedge, yedge = N.histogram2d(
             dsy, dsx, bins=[fields['binsy'], fields['binsx']],
-            range=[[miny,maxy], [minx,maxx]], normed=False)
+            range=[[miny,maxy], [minx,maxx]], density=False)
 
         m = fields['mode']
         if m == 'Count':


### PR DESCRIPTION
For issue https://github.com/veusz/veusz/issues/655

Update a deprecated `numpy.histogram2d()` keyword `normed` to the new keyword `density`.