### PR TITLE
Add srderr to PIPE in Popen

### DIFF
--- a/veusz/embed.py
+++ b/veusz/embed.py
@@ -249,6 +249,7 @@ class Embedded:
                         close_fds=False,
                         stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE
                     )
                     return
                 except OSError:


### PR DESCRIPTION
Without redirection of stderr there is no way to silence warnings that pop up while using veusz embed. In my case it was a bunch of fontconfig warnings:
```
Qt: Session management error: None of the authentication protocols specified are supported
Fontconfig warning: line 5: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/10-hinting-slight.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/10-scale-bitmap-fonts.conf", line 4: unknown element "description"
Fontconfig error: "/etc/fonts/conf.d/10-scale-bitmap-fonts.conf", line 72: non-double matrix element
Fontconfig error: "/etc/fonts/conf.d/10-scale-bitmap-fonts.conf", line 72: non-double matrix element
Fontconfig warning: "/etc/fonts/conf.d/10-scale-bitmap-fonts.conf", line 80: saw unknown, expected number
Fontconfig warning: "/etc/fonts/conf.d/10-sub-pixel-rgb.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/10-yes-antialias.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/11-lcdfilter-default.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/20-unhint-small-vera.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/30-metric-aliases.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/40-nonlatin.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/45-generic.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/45-latin.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/48-spacing.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/49-sansserif.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/50-user.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/51-local.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/60-generic.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/60-latin.conf", line 4: unknown element "description"
Fontconfig warning: "/etc/fonts/conf.d/65-nonlatin.conf", line 4: unknown element "description
```