### PR TITLE
Minor fixes for 2D data import with Transpose option

### DIFF
--- a/veusz/dataimport/simpleread.py
+++ b/veusz/dataimport/simpleread.py
@@ -795,7 +795,8 @@ class SimpleRead2D:
         # transpose matrix if requested
         if self.params.transpose:
             self.data = N.transpose(self.data).copy()
-            self.xedge, self.yedge = self.xedge, self.yedge
+            self.xedge, self.yedge = self.yedge, self.xedge
+            self.xcent, self.ycent = self.ycent, self.xcent
 
         # check orders of coords - flip if wrong
         for attr in 'xedge', 'xcent', 'yedge', 'ycent':


### PR DESCRIPTION
Swap `self.xcent` and `self.ycent`, as well as `self.xedge` and `self.yedge`, for 2D data import with Transpose option. (#692)