### PR TITLE
When copying svgfile or imagefile widgets, also put images themselves on clipboard.

### DIFF
--- a/veusz/document/mime.py
+++ b/veusz/document/mime.py
@@ -49,6 +49,7 @@ def generateWidgetsMime(widgets):
 
     header = [str(len(widgets))]
     savetext = []
+    mimedata = qt.QMimeData()
 
     for widget in widgets:
         header.append(widget.typename)
@@ -58,10 +59,28 @@ def generateWidgetsMime(widgets):
         header.append( str(save.count('\n')) )
         savetext.append(save)
 
+        if widget.typename == 'svgfile':
+            data = None
+            s = widget.settings
+            if s.filename == '{embedded}':
+                data = qt.QByteArray.fromBase64(s.embeddedSVGData.encode('ascii'))
+            else :
+                # get data from external file
+                try:
+                    with open(s.filename, 'rb') as f:
+                        data = f.read()
+                except EnvironmentError:
+                    print("Could not find image file. Not copying.")
+            if data is not None:
+                mimedata.setData(svgmime, qt.QByteArray(data))
+        elif widget.typename =='imagefile':
+            data = widget.cacheimage
+            if data is not None:
+                mimedata.setImageData(data)
+
     header.append('')
     text = ('\n'.join(header) + ''.join(savetext)).encode('utf-8')
 
-    mimedata = qt.QMimeData()
     mimedata.setData(widgetmime, qt.QByteArray(text))
     return mimedata
 


### PR DESCRIPTION
When one has added an image to a plot by pasting, the image is automatically embedded, and there is no straightforward way to de-embed that image (say, if you want to modify it, or copy it elsewhere, without having to look for its source).
This simple patch puts the images back onto the clipboard.