### PR TITLE
bugfix: Overlapping of FormatDock tabs on the titlebar

### DIFF
--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -701,6 +701,12 @@ class FormatDock(qt.QDockWidget):
         self.document = document
         self.tabwidget = None
 
+        self.container = qt.QWidget()
+        self.layout = qt.QVBoxLayout()
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.container.setLayout(self.layout)
+        self.setWidget(self.container)
+
         # update our view when the tree edit window selection changes
         treeedit.widgetsSelected.connect(self.selectedWidgets)
 
@@ -719,7 +725,7 @@ class FormatDock(qt.QDockWidget):
             self.tabwidget = None
 
         self.tabwidget = TabbedFormatting(self.document, setnsproxy)
-        self.setWidget(self.tabwidget)
+        self.layout.addWidget(self.tabwidget)
 
         # wrap tab from zero to max number
         tab = max( min(self.tabwidget.count()-1, tab), 0 )


### PR DESCRIPTION
# Issue
On macOS, the `FormatDock` tabs are overlapping with the dock title bar.

# Modification
The `QTabWidget` is now added within a `QVBoxLayout`, which is then set as the layout of a container widget inside the `QDockWidget`. This change avoids placing the tab widget directly in the dock, which caused the overlap.

# How It Was Changed
## Before the modification
### on macOS
Tabs are rendered on top of the dock title bar:
![before](https://github.com/user-attachments/assets/38b5d1d6-a474-49f5-bb79-b1e6f32522ba)

## After the modification
### macOS – The issue is resolved:
![after_macOS](https://github.com/user-attachments/assets/40f8e7f3-cb66-4d9a-bc2f-7c0cb19b9584)
### Ubuntu 24.04 / Windows 10, 11 – Appearance remains correct:
![after_Ubuntu](https://github.com/user-attachments/assets/ac841599-6230-455c-8be6-75caf7458e58)
