### PR TITLE
bugfix: Explicitly take out an old tab widget from layout

### DIFF
--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -720,9 +720,13 @@ class FormatDock(qt.QDockWidget):
             tab = 0
 
         # delete old tabwidget
-        if self.tabwidget:
-            self.tabwidget.deleteLater()
-            self.tabwidget = None
+        oldItem = self.layout.takeAt(0)
+        if oldItem:
+            oldWidget = oldItem.widget()
+            if oldWidget:
+                oldWidget.setParent(None)
+                oldWidget.deleteLater()
+                self.tabwidget = None
 
         self.tabwidget = TabbedFormatting(self.document, setnsproxy)
         self.layout.addWidget(self.tabwidget)


### PR DESCRIPTION
Related to https://github.com/veusz/veusz/pull/749

# Issue
A blank area appears in the formatting dock after removing an object.
Just removing the `tabWidget` is not enough to refresh it.
![スクリーンショット 2025-06-03 21 33 03](https://github.com/user-attachments/assets/deabffe2-99cd-4080-9b2c-fec521850d03)

# Modification
Use `takeAt()` to explicitly take out an old tab widget from the layout.

# Comment
I'm sorry for bothering you.