### PR TITLE
Force QApp ColorScheme to be Light for better visibility.

### DIFF
--- a/veusz/veusz_main.py
+++ b/veusz/veusz_main.py
@@ -160,6 +160,7 @@ class VeuszApp(qt.QApplication):
 
     def __init__(self):
         qt.QApplication.__init__(self, sys.argv)
+        self.styleHints().setColorScheme(qt.Qt.ColorScheme.Light)
 
         self.lastWindowClosed.connect(self.quit)
         self.signalException.connect(self.showException)


### PR DESCRIPTION
Qt will switch the ColorScheme to Dark when _Dark Mode for applications_ is activated, this makes widgets icons difficult to see clearly.

see https://doc.qt.io/qt-6/qguiapplication.html#platform-specific-arguments

and https://doc.qt.io/qt-6/qstylehints.html#setColorScheme

<img width="830" alt="Screenshot 2025-06-04 140335" src="https://github.com/user-attachments/assets/3b69a8f7-9c57-42dd-985f-fa0e6b2ff7f1" />

