### PR TITLE
Iteratively change a property of multiple widgets

### DIFF
--- a/veusz/setting/__init__.py
+++ b/veusz/setting/__init__.py
@@ -22,3 +22,4 @@ from .setting import *
 from .settings import *
 from .collections import *
 from .stylesheet import *
+from .controls import Dataset as ControlDataset

--- a/veusz/setting/controls.py
+++ b/veusz/setting/controls.py
@@ -702,7 +702,7 @@ class Dataset(qt.QWidget):
     """Allow the user to choose between the possible datasets."""
 
     sigSettingChanged = qt.pyqtSignal(qt.QObject, object, object)
-    sigIterativeSettingChanged = qt.pyqtSignal(qt.QObject, object, object)
+    sigSettingChangedIteratively = qt.pyqtSignal(qt.QObject, object, object)
 
     def __init__(self, setting, document, dimensions, datatype, parent):
         """Initialise the combobox. The list is populated with datasets.
@@ -788,7 +788,7 @@ class Dataset(qt.QWidget):
 
     def newDatasets(self, dsnames):
         """New datasets selected."""
-        self.sigIterativeSettingChanged.emit(self, self.choice.setting, dsnames)
+        self.sigSettingChangedIteratively.emit(self, self.choice.setting, dsnames)
 
 class DatasetOrString(Dataset):
     """Allow use to choose a dataset or enter some text."""

--- a/veusz/setting/controls.py
+++ b/veusz/setting/controls.py
@@ -700,6 +700,7 @@ class Dataset(qt.QWidget):
     """Allow the user to choose between the possible datasets."""
 
     sigSettingChanged = qt.pyqtSignal(qt.QObject, object, object)
+    sigIterativeSettingChanged = qt.pyqtSignal(qt.QObject, object, object)
 
     def __init__(self, setting, document, dimensions, datatype, parent):
         """Initialise the combobox. The list is populated with datasets.
@@ -772,6 +773,7 @@ class Dataset(qt.QWidget):
                 filterdtype=set((self.datatype,)) )
             d.closing.connect(self.boxClosing)
             d.newdataset.connect(self.newDataset)
+            d.newdatasets.connect(self.newDatasets)
             d.show()
 
     def boxClosing(self):
@@ -781,6 +783,10 @@ class Dataset(qt.QWidget):
     def newDataset(self, dsname):
         """New dataset selected."""
         self.sigSettingChanged.emit(self, self.choice.setting, dsname)
+
+    def newDatasets(self, dsnames):
+        """New datasets selected."""
+        self.sigIterativeSettingChanged.emit(self, self.choice.setting, dsnames)
 
 class DatasetOrString(Dataset):
     """Allow use to choose a dataset or enter some text."""

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -416,9 +416,11 @@ class PropertyList(qt.QWidget):
             lab = SettingLabel(self.document, setn, setnsproxy)
             self.layout.addWidget(lab, row, 0)
             self.childlist.append(lab)
+            
             cntrl.sigSettingChanged.connect(setnsproxy.onSettingChanged)
             if isinstance(cntrl, setting.ControlDataset):
-                cntrl.sigSettingChangedIteratively.connect(setnsproxy.onSettingChangedIteratively)
+                cntrl.sigSettingChangedIteratively.connect(
+                    setnsproxy.onSettingChangedIteratively)
             self.layout.addWidget(cntrl, row, 1)
             self.childlist.append(cntrl)
             self.setncntrls[setn.name] = (lab, cntrl)

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -56,7 +56,7 @@ class SettingsProxy:
     def onSettingChanged(self, control, setting, val):
         """Called when a setting has been modified."""
 
-    def onIterativeSettingChanged(self, control, setting, vals):
+    def onSettingChangedIteratively(self, control, setting, vals):
         """Called when a setting has been modified with multiple values."""
 
     def onAction(self, action, console):
@@ -125,7 +125,7 @@ class SettingsProxySingle(SettingsProxy):
             self.document.applyOperation(
                 document.OperationSettingSet(setting, val))
             
-    def onIterativeSettingChanged(self, control, setting, vals):
+    def onSettingChangedIteratively(self, control, setting, vals):
         """Change setting iteratively with multiple input values."""
         val = vals[0]
         self.onSettingChanged(control, setting, val)
@@ -267,7 +267,7 @@ class SettingsProxyMulti(SettingsProxy):
             self.document.applyOperation(
                 document.OperationMultiple(ops, descr=_('change settings')))
             
-    def onIterativeSettingChanged(self, control, setting, vals):
+    def onSettingChangedIteratively(self, control, setting, vals):
         """Change a setting of widgets iteratively with multiple values."""
         ops = []
         sname = setting.name
@@ -418,7 +418,7 @@ class PropertyList(qt.QWidget):
             self.childlist.append(lab)
             cntrl.sigSettingChanged.connect(setnsproxy.onSettingChanged)
             if isinstance(cntrl, setting.ControlDataset):
-                cntrl.sigIterativeSettingChanged.connect(setnsproxy.onIterativeSettingChanged)
+                cntrl.sigSettingChangedIteratively.connect(setnsproxy.onSettingChangedIteratively)
             self.layout.addWidget(cntrl, row, 1)
             self.childlist.append(cntrl)
             self.setncntrls[setn.name] = (lab, cntrl)

--- a/veusz/windows/treeeditwindow.py
+++ b/veusz/windows/treeeditwindow.py
@@ -54,6 +54,9 @@ class SettingsProxy:
     def onSettingChanged(self, control, setting, val):
         """Called when a setting has been modified."""
 
+    def onIterativeSettingChanged(self, control, setting, vals):
+        """Called when a setting has been modified with multiple values."""
+
     def onAction(self, action, console):
         """Called if action pressed. Console window is given."""
 
@@ -119,6 +122,11 @@ class SettingsProxySingle(SettingsProxy):
         if setting.val != val:
             self.document.applyOperation(
                 document.OperationSettingSet(setting, val))
+            
+    def onIterativeSettingChanged(self, control, setting, vals):
+        """Change setting iteratively with multiple input values."""
+        val = vals[0]
+        self.onSettingChanged(control, setting, val)
 
     def onAction(self, action, console):
         """Run action on console."""
@@ -250,6 +258,22 @@ class SettingsProxyMulti(SettingsProxy):
             sname = self._root + '/' + sname
         for w in self.widgets:
             s = self.document.resolveSettingPath(None, w.path+'/'+sname)
+            if s.val != val:
+                ops.append(document.OperationSettingSet(s, val))
+        # apply all operations
+        if ops:
+            self.document.applyOperation(
+                document.OperationMultiple(ops, descr=_('change settings')))
+            
+    def onIterativeSettingChanged(self, control, setting, vals):
+        """Change a setting of widgets iteratively with multiple values."""
+        ops = []
+        sname = setting.name
+        if self._root:
+            sname = self._root + '/' + sname
+        for i, w in enumerate(self.widgets):
+            val = vals[i % len(vals)]
+            s = self.document.resolveSettingPath(None, w.path + '/' + sname)
             if s.val != val:
                 ops.append(document.OperationSettingSet(s, val))
         # apply all operations
@@ -390,8 +414,9 @@ class PropertyList(qt.QWidget):
             lab = SettingLabel(self.document, setn, setnsproxy)
             self.layout.addWidget(lab, row, 0)
             self.childlist.append(lab)
-
             cntrl.sigSettingChanged.connect(setnsproxy.onSettingChanged)
+            if isinstance(cntrl, setting.ControlDataset):
+                cntrl.sigIterativeSettingChanged.connect(setnsproxy.onIterativeSettingChanged)
             self.layout.addWidget(cntrl, row, 1)
             self.childlist.append(cntrl)
             self.setncntrls[setn.name] = (lab, cntrl)


### PR DESCRIPTION
# Issue 

Currently, users can only select one dataset at a time for dataset-related operations. There is demand to allow selecting multiple datasets and assign them to multiple widgets simultaneously to streamline workflows.

Related discussions/issues:

- https://github.com/veusz/veusz/issues/225
- https://www.reddit.com/r/Veusz/comments/apqy35/easier_methods_for_adding_multiple_xy_plots/
- https://veusz-discuss.gna.narkive.com/BofupLLE/plotting-multiple-datasets

# How it works
This modification enables users to select multiple datasets via the dataset browser and assign them iteratively to selected widgets at once.

![trim](https://github.com/user-attachments/assets/bd1e0f3b-a8f8-4492-99ff-0fc5c8133eec)

When this operation is executed with **N** selected widgets and **M** selected datasets, the dataset assigned to the **n-th** widget is the dataset indexed by (**n % M**). This allows cycling through datasets if there are more widgets than datasets.

The order in which datasets are assigned depends on the modifier keys used during selection:
- Holding Shift while selecting datasets assigns indices in ascending order from top to bottom.
- Holding Ctrl while selecting datasets assigns indices in the exact order the datasets were selected.

I have used this feature for about a month and found it to be convenient and versatile. 
I believe many users will find it useful as well.