### PR TITLE
Remove BOMs planted in veusz files before loading them

### DIFF
--- a/veusz/dialogs/importdialog.py
+++ b/veusz/dialogs/importdialog.py
@@ -143,7 +143,7 @@ class ImportDialog(VeuszDialog):
 
         # further defaults
         self.encodingcombo.defaultlist = utils.encodings
-        self.encodingcombo.defaultval = 'utf_8_sig'
+        self.encodingcombo.defaultval = 'utf_8'
 
         # load icon for clipboard
         self.clipbutton.setIcon( utils.getIcon('kde-clipboard') )

--- a/veusz/dialogs/importdialog.py
+++ b/veusz/dialogs/importdialog.py
@@ -143,7 +143,7 @@ class ImportDialog(VeuszDialog):
 
         # further defaults
         self.encodingcombo.defaultlist = utils.encodings
-        self.encodingcombo.defaultval = 'utf_8'
+        self.encodingcombo.defaultval = 'utf_8_sig'
 
         # load icon for clipboard
         self.clipbutton.setIcon( utils.getIcon('kde-clipboard') )

--- a/veusz/document/loader.py
+++ b/veusz/document/loader.py
@@ -325,8 +325,9 @@ def removeBOMs(script):
     For example:
         "\ufeffAAAA" -> "AAAA"
         '\ufeffBBBB' -> 'BBBB'
+        `\ufeffCCCC` -> `CCCC`
     """
-    pattern = r"([\"'])\\ufeff(.*?)\1"
+    pattern = r"([\"'`])\\ufeff(.*?)\1"
     found = re.findall(pattern, script)
     if found:
         script = re.sub(pattern, lambda m: f"{m.group(1)}{m.group(2)}{m.group(1)}", script)

--- a/veusz/document/loader.py
+++ b/veusz/document/loader.py
@@ -323,12 +323,18 @@ def removeBOMs(script):
     """
     Remove BOM at the start of quoted strings.
     For example:
-        "\ufeffAAAA" -> "AAAA"
-        '\ufeffBBBB' -> 'BBBB'
-        `\ufeffCCCC` -> `CCCC`
+        "AA\ufeffAA" -> "AAAA"
+        'BB\ufeffBB' -> 'BBBB'
+        `CC\ufeffCC` -> `CCCC`
     """
-    pattern = r"([\"'`])\\ufeff(.*?)\1"
-    found = re.findall(pattern, script)
-    if found:
-        script = re.sub(pattern, lambda m: f"{m.group(1)}{m.group(2)}{m.group(1)}", script)
-    return script
+    pattern = r'([\'"`])(.*?)(\\+)ufeff(.*?)\1'
+    def replacer(m):
+        quote = m.group(1)
+        backslashes = m.group(3)
+        num_bs = len(backslashes)
+        if num_bs % 2 == 0:
+            return m.group(0)
+        else:
+            new_bs = "\\" * (num_bs - 1)
+            return f"{quote}{m.group(2)}{new_bs}{m.group(4)}{quote}"
+    return re.sub(pattern, replacer, script)

--- a/veusz/document/loader.py
+++ b/veusz/document/loader.py
@@ -260,7 +260,7 @@ def loadHDF5Doc(thedoc, filename,
         script = hdffile['Veusz']['Document']['document'][0].decode('utf-8')
 
         # Remove embedded BOM characters
-        script = remove_boms(script)
+        script = removeBOMs(script)
 
         # execute script
         executeScript(
@@ -297,7 +297,7 @@ def loadDocument(thedoc, filename, mode='vsz',
                 os.path.basename(filename) )
         
         # Remove embedded BOM characters
-        script = remove_boms(script)
+        script = removeBOMs(script)
 
         thedoc.wipe()
         thedoc.filename = filename
@@ -319,13 +319,12 @@ def loadDocument(thedoc, filename, mode='vsz',
     thedoc.setModified(False)
     thedoc.clearHistory()
 
-def remove_boms(script):
+def removeBOMs(script):
     """
-    Remove BOM at the start of quoted strings (single or double quotes).
+    Remove BOM at the start of quoted strings.
     For example:
         "\ufeffAAAA" -> "AAAA"
         '\ufeffBBBB' -> 'BBBB'
-    Only affects BOM at the start of quoted strings.
     """
     pattern = r"([\"'])\\ufeff(.*?)\1"
     found = re.findall(pattern, script)

--- a/veusz/document/loader.py
+++ b/veusz/document/loader.py
@@ -261,8 +261,7 @@ def loadHDF5Doc(thedoc, filename,
 
         # Remove embedded BOM characters
         script = removeBOMs(script)
-
-        # execute script
+        
         executeScript(
             thedoc, filename, script,
             callbackunsafe=callbackunsafe,
@@ -321,20 +320,16 @@ def loadDocument(thedoc, filename, mode='vsz',
 
 def removeBOMs(script):
     """
-    Remove BOM at the start of quoted strings.
+    Remove BOMs in the script unless they are escaped.
     For example:
         "AA\ufeffAA" -> "AAAA"
-        'BB\ufeffBB' -> 'BBBB'
-        `CC\ufeffCC` -> `CCCC`
+        'C:\\ufeff\\a.csv' -> 'C:\\ufeff\\a.csv'
     """
-    pattern = r'([\'"`])(.*?)(\\+)ufeff(.*?)\1'
+    pattern = r'(.*?)(\\+)ufeff(.*?)'
     def replacer(m):
-        quote = m.group(1)
-        backslashes = m.group(3)
-        num_bs = len(backslashes)
-        if num_bs % 2 == 0:
+        bs = m.group(2)
+        if len(bs) % 2 == 0:
             return m.group(0)
         else:
-            new_bs = "\\" * (num_bs - 1)
-            return f"{quote}{m.group(2)}{new_bs}{m.group(4)}{quote}"
+            return f"{m.group(1)}{bs[1:]}{m.group(3)}"
     return re.sub(pattern, replacer, script)


### PR DESCRIPTION
The latest commit ( https://github.com/veusz/veusz/commit/2b5d6a7537fc65502186536b2ade850664f82b6c ) will prevent BOMs to be unintentionally imported in future.
Still, existing .vsz or .vszh5 files created by Veusz before ver. 4.1 may contain BOM strings, which cause errors.
e.g.) [sample_362.vsz.txt](https://github.com/user-attachments/files/21577099/sample_362.vsz.txt)

This PR removes BOM strings (`ufeff`) from loaded Veusz scripts unless they are escaped as `\\ufeff`.

The following bugs related to mixed BOMs that existed in Veusz versions prior to 3.6.2 have also been fixed.
- Incorrect order of datasets containing BOMs
- “Not found” error occurs when manually entering dataset names containing BOMs

Related: https://github.com/veusz/veusz/issues/762