### PR TITLE
Negative offsets of labels

### DIFF
--- a/veusz/setting/controls.py
+++ b/veusz/setting/controls.py
@@ -698,6 +698,13 @@ class DistancePt(Choice):
         '''Initialise with blank list, then populate with sensible units.'''
         Choice.__init__(self, setting, True, DistancePt.points, parent)
 
+class DisplacementPt(DistancePt):
+    """For editing displacements with defaults in points."""
+
+    def __init__(self, setting, parent, allowauto=False):
+        '''Initialise with blank list, then populate with sensible units.'''
+        Choice.__init__(self, setting, True, DisplacementPt.points, parent)
+
 class Dataset(qt.QWidget):
     """Allow the user to choose between the possible datasets."""
 

--- a/veusz/setting/setting.py
+++ b/veusz/setting/setting.py
@@ -633,7 +633,7 @@ def _distRatio(match, painter):
 distre_expr = r'''^
  [ ]*                                # optional whitespace
 
- (\.?[0-9]+|[0-9]+\.[0-9]*)          # a floating point number
+ (\.?[0-9]+|[0-9]+\.[0-9]*)          # a floating point number (positive only)
 
  [ ]*                                # whitespace
 
@@ -795,6 +795,37 @@ class DistanceOrAuto(Distance):
 
     def makeControl(self, *args):
         return controls.Distance(self, allowauto=True, *args)
+
+# regular expression to match displacements
+dispre_expr = r'''^
+ [ ]*                                # optional whitespace
+
+ ([+-]?(?:\.?[0-9]+|[0-9]+\.[0-9]*)) # a floating point number (positive or negative)
+
+ [ ]*                                # whitespace
+
+ (cm|pt|mm|inch|in|"|%||             # ( unit, no unit,
+  (?P<slash>/) )                     # or / )
+
+ (?(slash)[ ]*                       # if it was a slash, match any whitespace
+  (\.?[0-9]+|[0-9]+\.[0-9]*))        # and match following fp number
+
+ [ ]*                                # optional whitespace
+$'''
+
+class Displacement(Distance):
+    """Subspecies of 'Distance' to allow negative numbers."""
+
+    typename = 'displacement'
+
+    # match a displacement
+    distre = re.compile(dispre_expr, re.VERBOSE)
+
+class DisplacementPt(Displacement):
+    """For a displacement in points."""
+
+    def makeControl(self, *args):
+        return controls.DisplacementPt(self, *args)
 
 class Choice(Setting):
     """One out of a list of strings."""

--- a/veusz/widgets/axis.py
+++ b/veusz/widgets/axis.py
@@ -128,7 +128,7 @@ class AxisLabel(setting.Text):
             'rotate', '0',
             descr='Angle by which to rotate label by',
             usertext='Rotate') )
-        self.add( setting.DistancePt(
+        self.add( setting.DisplacementPt(
             'offset',
             '0pt',
             descr=_('Additional offset of axis label from axis tick labels'),
@@ -173,7 +173,7 @@ class TickLabel(setting.Text):
             descr=_('A scale factor to apply to the values of the tick labels'),
             usertext=_('Scale') ) )
 
-        self.add( setting.DistancePt(
+        self.add( setting.DisplacementPt(
             'offset',
             '0pt',
             descr = _('Additional offset of axis tick labels from axis'),


### PR DESCRIPTION
This PR addresses the following issues:
- https://github.com/veusz/veusz/issues/181
- https://github.com/veusz/veusz/issues/720

**Summary**
This PR enables negative offsets for axis and tick labels.

**Implementation**
A new `Displacement` class was added as a subclass of `Distance`, allowing negative floating-point values. 
The change is internal only, with no impact on the public API.