### PR TITLE
Fix 3D plot marker border width changing with page scale when “Scale = True”

### DIFF
--- a/src/threed/scene.cpp
+++ b/src/threed/scene.cpp
@@ -216,16 +216,10 @@ void Scene::drawPath(QPainter* painter, const Fragment& frag,
   else
     {
       // scale point and relocate
-      QPainterPath path(*(pars->path));
-      int elementct = path.elementCount();
-      for(int i=0; i<elementct; ++i)
-        {
-          QPainterPath::Element el = path.elementAt(i);
-          path.setElementPositionAt(i,
-                                    el.x*scale+pt1.x(),
-                                    el.y*scale+pt1.y());
-        }
-      painter->drawPath(path);
+      QTransform t;
+      t.translate(pt1.x(), pt1.y());
+      t.scale(scale, scale);
+      painter->drawPath(t.map(*(pars->path)));
     }
 }
 
@@ -310,7 +304,10 @@ void Scene::doDrawing(QPainter* painter, const Mat3& screenM, double linescale,
                  ((frag.lineprop!=0 && frag.lineprop->hasRGBs())))
                 {
                   lline = frag.lineprop;
-                  painter->setPen(lineProp2QPen(frag, linescale));
+                const FragmentPathParameters* pars = 
+                  static_cast<const FragmentPathParameters*>(frag.params);
+                painter->setPen(lineProp2QPen(
+                  frag, pars && pars->scaleline ? 1.0 : linescale));
                 }
               if(ltype != frag.type || lsurf != frag.surfaceprop ||
                  (frag.surfaceprop!=0 && (frag.surfaceprop->hasRGBs() ||


### PR DESCRIPTION
## Issue
In 3D plots with `scale=True` in Marker border property, marker border widths change with the page/output scale.
This issue causes significant differences in the appearance of marker outlines between the app and the exported images.
Related issue: https://github.com/veusz/veusz/issues/556

## Issue example
The official [3d_example.vsz](https://veusz.github.io/examples3d/3d_example.vsz) at different page widths (e.g., 1.5 cm, 15 cm, 150 cm).

**Expected**: All outputs should show the same ralative marker border width.
**Observed**: With `Scale=True`, marker border widths varied with the page width.

<img width="1464" height="1135" alt="image" src="https://github.com/user-attachments/assets/a1d9001c-4344-418f-b3e1-adb7529c7b8f" />

## Cause

In `veusz/src/threed/scene.cpp`, the device scale (`linescale`) was applied to the stroke **twice** when `Scale = True`:

1. **Pen build** (`Scene::lineProp2QPen(...)`): `PenWidth = BaseBorderWidth × linescale`
2. **Geometry transform** (`Scene::drawPath(...)`): `painter.scale(pathsize × linescale × distscale)`

Resulting formulas:

* **Scale = False**
  `EffectiveBorderWidth = BaseBorderWidth × DeviceScale`

* **Scale = True (bug)**
  `EffectiveBorderWidth = BaseBorderWidth × DeviceScale × MarkerSizeScale × DeviceScale × PerspectiveScale`

**DeviceScale** is defined as `linescale` in `veusz/src/threed/scene.cpp`:

```cpp
// device scale
double linescale = std::max(std::abs(x2-x1), std::abs(y2-y1)) * (1./1000);
```

## Fix
Give `linescale = 1.0` for the Pen build when Scale line = True.

Resulting formulas:

* **Scale = False (unchanged)**
  `EffectiveBorderWidth = BaseBorderWidth × DeviceScale`

* **Scale = True (fixed)**
  `EffectiveBorderWidth = BaseBorderWidth × MarkerSizeScale × DeviceScale × PerspectiveScale`